### PR TITLE
LINUX - Use local Chromium install if available

### DIFF
--- a/frontend/chromium_manager.py
+++ b/frontend/chromium_manager.py
@@ -8,6 +8,7 @@ positioned on the correct monitor with fullscreen.
 
 import os
 import sys
+from shutil import which
 import platform
 import subprocess
 import tempfile
@@ -36,6 +37,10 @@ def get_chromium_path():
     elif system == "Darwin":
         return resource_path("chromium/Chromium.app/Contents/MacOS/Chromium")
     elif system == "Linux":
+        # Check if chromium is locally available on the system. 
+        # If so use that instead of bundled chromium.
+        if which("chromium") is not None:
+            return which("chromium")
         return resource_path("chromium/linux/chrome/chrome")
     else:
         raise RuntimeError(f"Unsupported OS: {system}")


### PR DESCRIPTION
Should in theory also work for Windows and OS X, as shutil which is cross platform. Here there could be checks for other available chromium based browsers.