### PR TITLE
WIN - Use Microsoft Edge if Chrome is not available

### DIFF
--- a/frontend/chromium_manager.py
+++ b/frontend/chromium_manager.py
@@ -40,6 +40,7 @@ def get_chromium_path():
             os.path.expandvars(r"%LocalAppData%\Google\Chrome\Application\chrome.exe"),
             os.path.expandvars(r"%ProgramFiles%\Chromium\Application\chrome.exe"),
             os.path.expandvars(r"%LocalAppData%\Chromium\Application\chrome.exe"),
+            os.path.expandvars(r"%ProgramFiles(x86)%\Microsoft\Edge\Application\msedge.exe")
         ]
         for path in common_paths:
             if os.path.isfile(path):


### PR DESCRIPTION
Edge is installed by default on Windows and is chromium based. Looks to work fine so far.

Is very likely to be present on 99.9% of all systems as removing Edge isn't without it's issues.