### PR TITLE
Added setting to disable the splash screen

### DIFF
--- a/common/iniconfig.py
+++ b/common/iniconfig.py
@@ -16,7 +16,8 @@ class IniConfig:
 				'tablescreenid': '0',
 				'tableorientation': 'landscape',
 				'tablerotation': '0',
-				'cabmode': 'false'
+				'cabmode': 'false',
+				'splashscreen': 'true'
 			},
 			'Settings': {
 				'vpxbinpath': '',

--- a/frontend/api.py
+++ b/frontend/api.py
@@ -603,6 +603,9 @@ class API:
     ### For splash page
     ###################
 
+    def get_splashscreen_enabled(self):
+        return self._iniConfig.config['Displays'].get('splashscreen', 'true')
+
     def get_theme_name(self):
         return self._iniConfig.config['Settings'].get('theme', 'default')
 

--- a/frontend/ws_bridge.py
+++ b/frontend/ws_bridge.py
@@ -53,6 +53,7 @@ class WebSocketBridge:
         'get_theme_name',
         'get_table_orientation',
         'get_table_rotation',
+        'get_splashscreen_enabled',
         'get_cab_mode',
         'get_theme_assets_port',
         'get_theme_index_page',

--- a/managerui/pages/vpinfe_config.py
+++ b/managerui/pages/vpinfe_config.py
@@ -43,7 +43,6 @@ FRIENDLY_NAMES = {
     'tablerootdir': 'Tables Directory',
     'startup_collection': 'Startup Collection',
     'autoupdatemediaonstartup': 'Auto Update Media On Startup',
-    'cabmode': 'Cabinet Mode',
     'enabledof': 'Enable DOF',
     'dofconfigtoolapikey': 'DOF Config Tool API Key',
     'theme': 'Active Theme',
@@ -56,6 +55,8 @@ FRIENDLY_NAMES = {
     'dmdscreenid': 'DMD Monitor ID',
     'tablerotation': 'Playfield Rotation (0/90/270)',
     'tableorientation': 'Playfield Orientation (Landscape/Portrait)',
+    'cabmode': 'Cabinet Mode',
+    'splashscreen': 'Enable splashscreen',
     
     # [Network]
     'http_port': 'Web Server Port',
@@ -428,7 +429,7 @@ def render_panel(tab=None):
                                         value=value
                                     ).classes('config-input').style('min-width: 200px;')
                                 # Special handling for startup media auto-update in Settings
-                                elif (section == 'Settings' and key == 'autoupdatemediaonstartup') or (section == 'Displays' and key == 'cabmode') or (section == 'DOF' and key == 'enabledof'):
+                                elif (section == 'Settings' and key == 'autoupdatemediaonstartup') or (section == 'Displays' and key == 'cabmode') or (section == 'Displays' and key == 'splashscreen') or (section == 'DOF' and key == 'enabledof'):
                                     bool_options = ['true', 'false']
                                     normalized = (value or '').strip().lower()
                                     if normalized not in bool_options:

--- a/web/splash.html
+++ b/web/splash.html
@@ -64,6 +64,14 @@
         window.location = location;
       };
 
+      const splashEnabled = await vpin.call("get_splashscreen_enabled");
+      console.log(splashEnabled)
+      if (splashEnabled == "false") {
+        console.log("Splash disabled")
+        redirectToTheme();
+        return
+      } 
+
       const splashRoot = document.getElementById('splash-root');
       const splashVideo = document.getElementById('splash');
       const splashVideoSource = document.getElementById('splash-source');


### PR DESCRIPTION
Allows the user to skip the splash screen by setting the Splash screen enabled value to false.
By default it is set to enabled.