### PR TITLE
Manager UI public toggle - Disable Terminal if public

### DIFF
--- a/common/iniconfig.py
+++ b/common/iniconfig.py
@@ -53,6 +53,7 @@ class IniConfig:
 			'Network': {
 				'themeassetsport': '8000',
 				'manageruiport': '8001',
+				'manageruipublic': 'false'
 				},
 			'DOF': {
 				'enabledof': 'false',

--- a/main.py
+++ b/main.py
@@ -151,7 +151,9 @@ if iniconfig.is_new:
     import time
     set_first_run(True)
     manager_ui_port = int(iniconfig.config['Network'].get('manageruiport', '8001'))
-    start_manager_ui(port=manager_ui_port)
+    manager_ui_host = "0.0.0.0" if iniconfig.config['Network'].get('manageruipublic', 'true') == "true" else "127.0.0.1"
+
+    start_manager_ui(port=manager_ui_port, host=manager_ui_host)
     reconfigure_app_logging()
     # Wait for the NiceGUI server to be ready before chromium tries to load it
     for _attempt in range(30):
@@ -197,7 +199,8 @@ http_server.start_file_server(port=theme_assets_port)
 
 # Start the NiceGUI HTTP server
 manager_ui_port = int(iniconfig.config['Network'].get('manageruiport', '8001'))
-start_manager_ui(port=manager_ui_port)
+manager_ui_host = "0.0.0.0" if iniconfig.config['Network'].get('manageruipublic', 'true') == "true" else "127.0.0.1"
+start_manager_ui(port=manager_ui_port, host=manager_ui_host)
 reconfigure_app_logging()
 
 # Start the WebSocket bridge

--- a/managerui/managerui.py
+++ b/managerui/managerui.py
@@ -532,6 +532,7 @@ def set_remote_launch_state(launching: bool, table_name: str = None):
 _ui_thread = None
 
 _ui_port = 8001
+_ui_host = "0.0.0.0"
 
 
 def _manager_ui_urls(port: int) -> list[str]:
@@ -557,18 +558,19 @@ def _run_ui():
     nicegui_storage_dir.mkdir(parents=True, exist_ok=True)
     os.environ["NICEGUI_STORAGE_PATH"] = str(nicegui_storage_dir)
     logger.info("Using NiceGUI storage path: %s", nicegui_storage_dir)
-    logger.info("Starting Manager UI on host=0.0.0.0 port=%s", _ui_port)
+    logger.info("Starting Manager UI on host=%s port=%s", _ui_host, _ui_port)
     logger.info("Manager UI expected URLs: %s", ", ".join(_manager_ui_urls(_ui_port)))
     ui.run(title='VPinFE Manager UI',
-           host='0.0.0.0',
+           host=_ui_host,
            port=_ui_port,
            reload=False,
            show=False,
            storage_secret=STORAGE_SECRET)
 
-def start_manager_ui(port=8001):
-    global _ui_thread, _ui_port
+def start_manager_ui(port=8001,host="0.0.0.0"):
+    global _ui_thread, _ui_port, _ui_host
     _ui_port = port
+    _ui_host = host
     if _ui_thread and _ui_thread.is_alive():
         logger.info("Manager UI is already running")
         return _ui_thread

--- a/managerui/pages/terminal.py
+++ b/managerui/pages/terminal.py
@@ -120,6 +120,12 @@ def render_panel(tab=None):
     if client_id in _SESSIONS:
         _close_session(client_id)
 
+    if os.environ['NICEGUI_HOST'] == "0.0.0.0":
+        with ui.column().classes('w-full'):
+            with ui.card().classes('w-full p-4'):
+                ui.label('Terminal is not available when management interface is publicly accessible.').classes('text-red-400')
+        return
+
     if not (pty and fcntl and termios):
         with ui.column().classes('w-full'):
             with ui.card().classes('w-full p-4'):

--- a/managerui/pages/vpinfe_config.py
+++ b/managerui/pages/vpinfe_config.py
@@ -74,6 +74,7 @@ FRIENDLY_NAMES = {
     'http_port': 'Web Server Port',
     'themeassetsport': 'Theme Server Port',
     'manageruiport': 'Manager UI Port',
+    'manageruipublic': 'Manager UI is accessible on other computers (Restart required)',
     'startup_collection': 'Default Startup Collection',
     # [Mobile]
     'deviceip': 'Mobile Device IP',
@@ -481,6 +482,7 @@ def render_panel(tab=None):
             or (section == 'Logger' and key == 'console')
             or (section == 'Settings' and key == 'splashscreen')
             or (section == 'DOF' and key == 'enabledof')
+            or (section == 'Network' and key == 'manageruipublic')
         )
 
         with ui.element('div').classes(
@@ -679,6 +681,16 @@ def render_panel(tab=None):
                                             value = config.config.get(section, key, fallback='')
                                             build_config_input(section, key, value)
 
+                            if section == 'Network':
+                                with ui.card().classes('config-side-card w-full mt-4 p-4'):
+                                    ui.label('Warning about publicly accessible management UI').classes('text-lg font-semibold text-white')
+                                    ui.label(
+                                        'Anyone on your local network can connect and access the management UI when the Manager UI is set to be accessible on other computers. This can be a security risk and should be enabled with care.'
+                                    ).classes('text-sm text-slate-300')
+                                    ui.label(
+                                        'The terminal will be disabled when the Manager UI is accessible by other computers.'
+                                    ).classes('text-sm text-slate-300')
+                                    
                             if section == 'Displays':
                                 with ui.card().classes('config-side-card w-full p-4 gap-3'):
                                     ui.label('Detected Displays').classes('text-lg font-semibold text-white')


### PR DESCRIPTION
The current terminal implementation is currently a wide open backdoor to computers running VPinFe. Everyone can simply access the management UI and get access to a nice logged in terminal. **This needs to change**

One way of solving this is not letting the management UI be public, unless the user specifically choose to do so.

This change adds a toggle that decides if the management UI is bound to 0.0.0.0 (Public) or 127.0.0.1 (Localhost)
When the UI is bound to 0.0.0.0 the terminal page will be disabled, as to not give out a public facing open terminal. 