### PR TITLE
Fix cli buildmeta

### DIFF
--- a/common/tableparser.py
+++ b/common/tableparser.py
@@ -75,7 +75,6 @@ class TableParser:
                     'folder': table.tableDirName,
                     'path': str(table_dir),
                 })
-                continue
 
             # check for addons
             if "pupvideos" in table_subdirs:


### PR DESCRIPTION
Tables missing info should still be added to the main tables list as that's what `--buildmeta` uses.

Bug from [6c40c8afc82dca041a9b247409a48a52d675fbc9](https://github.com/superhac/vpinfe/commit/6c40c8afc82dca041a9b247409a48a52d675fbc9#diff-b297c568b1b42f0cb857d3ee25ee658b5b73a8d35a0428e9cb87df66f6b06f80R53-R59).