### PR TITLE
Linux - Fix LD_LIBRARY_PATH on VPX loading.

### DIFF
--- a/frontend/launch_service.py
+++ b/frontend/launch_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
+import platform
 import subprocess
 import sys
 import time
@@ -118,6 +119,15 @@ def launch_table(
         logger.info("Launching: %s", cmd)
         launch_env = os.environ.copy()
         launch_env.update(parse_launch_env_overrides(settings.vpx_launch_env))
+        
+        # Prevent usage of bundled libaries on Linux
+        # PyInstaller bundles libaries which might be incompatible with the local files.
+        system = platform.system()
+        if system == "Linux" and getattr(sys, "frozen", False): 
+            lp_key = 'LD_LIBRARY_PATH'
+            lp_orig = launch_env.get(lp_key + '_ORIG')
+            if lp_orig is not None:
+                launch_env[lp_key] = lp_orig  # restore the original, unmodified value
 
         process = popen(
             cmd,

--- a/managerui/pages/remote.py
+++ b/managerui/pages/remote.py
@@ -1,3 +1,4 @@
+import platform
 import subprocess
 import os
 import logging
@@ -170,6 +171,15 @@ def _launch_table(table: dict):
         launch_env.update(
             parse_launch_env_overrides(cfg.config['Settings'].get('vpxlaunchenv', ''))
         )
+
+        # Prevent usage of bundled libaries on Linux
+        # PyInstaller bundles libaries which might be incompatible with the local files.
+        system = platform.system()
+        if system == "Linux" and getattr(sys, "frozen", False): 
+            lp_key = 'LD_LIBRARY_PATH'
+            lp_orig = launch_env.get(lp_key + '_ORIG')
+            if lp_orig is not None:
+                launch_env[lp_key] = lp_orig  # restore the original, unmodified value
 
         def run_and_wait():
             try:

--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,11 @@ The install is the same for all platforms you need to download the right release
 
 The latest version can be downloaded from [Releases](https://github.com/superhac/vpinfe/releases).
 
+### AUR (Arch Linux & Derivatives)
+VpinFE can also be downloaded from the AUR [vpinfe](https://aur.archlinux.org/packages/vpinfe) package maintained by @superrob
+
+The package handles installing and setups desktop entries for easy launching and updating.
+
 ## Running
 
 ### Linux (X64 & ARM)
@@ -54,11 +59,6 @@ Download the latest release and unzip it and then run:
 ```
 cd vpinfe
 ./vpinfe
-```
-
-If your on Arch or an Arch based disto (like Cachyos) then @superrob has created a distro [package](https://aur.archlinux.org/packages/vpinfe) for you.  
-```
-sudo pacman -S vpinfe
 ```
 
 ### MAC


### PR DESCRIPTION
The same library path issue as with #60 will happen on VPX loading. This adds the change to the two methods of launching VPX.

This request also has a change to the README regarding installing from the AUR.