### PR TITLE
Preserve unknown top-level sections in .info on rebuild

### DIFF
--- a/common/metaconfig.py
+++ b/common/metaconfig.py
@@ -123,12 +123,21 @@ class MetaConfig:
 
         medias = self.data.get("Medias", {})
 
+        # Preserve any top-level sections we don't manage (e.g. metadata written by
+        # other tools sharing the .info file) instead of dropping them on rebuild.
+        preserved = {
+            k: v
+            for k, v in self.data.items()
+            if k not in ("Info", "User", "VPXFile", "VPinFE", "Medias")
+        }
+
         self.data = {
             "Info": info,
             "User": user,
             "VPXFile": vpxfile,
             "VPinFE": vpinfe,
-            "Medias": medias
+            "Medias": medias,
+            **preserved
         }
 
         self.writeConfig()

--- a/tests/test_metaconfig.py
+++ b/tests/test_metaconfig.py
@@ -167,6 +167,29 @@ class TestMetaConfig(unittest.TestCase):
                 "https://pinballprimer.github.io/from_nested.html",
             )
 
+    def test_write_config_meta_preserves_unknown_top_level_sections(self) -> None:
+        with TemporaryDirectory() as tmp:
+            info_path = Path(tmp) / "Example Table.info"
+            info_path.write_text(
+                json.dumps(
+                    {
+                        "VPXFile": {
+                            "filehash": "old-filehash",
+                        },
+                        "ThirdParty": {
+                            "source": "vpforums",
+                            "fileId": "12210",
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            saved = self._write_meta(info_path)
+
+            self.assertEqual(saved["ThirdParty"], {"source": "vpforums", "fileId": "12210"})
+            self.assertEqual(saved["Info"]["Title"], "Example Table")
+
     def test_empty_info_file_reports_path(self) -> None:
         with TemporaryDirectory() as tmp:
             info_path = Path(tmp) / "Empty Table.info"


### PR DESCRIPTION
Fixes #64.

`writeConfigMeta()` rebuilt the `.info` from its five known sections and dropped any other top-level section. This keeps unknown sections instead, so metadata written by other tools sharing the file survives a rebuild. The known sections are written first, unknowns appended after.

Added a test that writes an extra top-level section and checks it's still there after a rebuild. Ran the metaconfig tests locally, all pass.
