### PR TITLE
web: build asset/WS/manager URLs from window.location instead of 127.0.0.1

### DIFF
--- a/web/common/vpinfe-core.js
+++ b/web/common/vpinfe-core.js
@@ -801,7 +801,7 @@ class VPinFECore {
   // **********************************************
 
   #connectWebSocket() {
-    const wsUrl = `ws://127.0.0.1:${this.wsPort}?window=${this._windowName}`;
+    const wsUrl = `ws://${window.location.hostname}:${this.wsPort}?window=${this._windowName}`;
     console.log(`[WS] Connecting to ${wsUrl}`);
     this._ws = new WebSocket(wsUrl);
 
@@ -1211,12 +1211,12 @@ async #onButtonPressed(buttonIndex, gamepadIndex) {
     // Check if the path includes a medias/ subfolder
     if (parts.length >= 3 && parts[parts.length - 2] === 'medias') {
       const tableDir = parts[parts.length - 3];  // table folder is 3rd from end
-      return `http://127.0.0.1:${port}/tables/${encodeURIComponent(tableDir)}/medias/${encodeURIComponent(file)}`;
+      return `http://${window.location.hostname}:${port}/tables/${encodeURIComponent(tableDir)}/medias/${encodeURIComponent(file)}`;
     }
 
     // Fallback: image is directly in table folder
     const dir = parts[parts.length - 2];     // second-to-last part = folder
-    return `http://127.0.0.1:${port}/tables/${encodeURIComponent(dir)}/${encodeURIComponent(file)}`;
+    return `http://${window.location.hostname}:${port}/tables/${encodeURIComponent(dir)}/${encodeURIComponent(file)}`;
   }
 
   async #showmenu() {
@@ -1385,7 +1385,7 @@ async #onButtonPressed(buttonIndex, gamepadIndex) {
     if (window.location.protocol === 'file:') return;
 
     const pollInterval = 1000; // Poll every 1 second
-    const managerUrl = `http://127.0.0.1:${this.managerUiPort}/api/remote-launch`;
+    const managerUrl = `http://${window.location.hostname}:${this.managerUiPort}/api/remote-launch`;
 
     console.log("[RemoteLaunch] Starting poll to:", managerUrl);
 


### PR DESCRIPTION
vpinfe-core.js hardcodes `127.0.0.1` in four places: the theme WebSocket bridge URL, the two table media URL builders, and the manager remote-launch endpoint. On the vpinfe machine itself this works, but opening a theme page from any other device (previewing/developing a theme in a desktop browser, driving the UI from a phone or another PC on the LAN) loads the page and then points every asset request and the WS bridge at the *viewing* machine instead of the vpinfe host, so nothing loads.

This changes those four URLs to `window.location.hostname`. Same-host behaviour is identical (it resolves to the same loopback the page was served from); pages served to another device now work.

Tested on a Batocera cabinet (three local chromium windows — unchanged behaviour) and from a LAN desktop browser + phone against the same instance (theme pages now fully load and connect).

Disclosure: this change was authored with AI assistance (Claude), then deployed and verified on real hardware as described.