### PR TITLE
Add chromeoptionsexclude: drop individual default Chromium flags

### DIFF
--- a/common/iniconfig.py
+++ b/common/iniconfig.py
@@ -42,6 +42,7 @@ class IniConfig:
 				'splashscreen': 'false',
 				'muteaudio': 'false',
 				'chromeoptions': '',
+				'chromeoptionsexclude': '',
 				'disabledefaultchromeoptions': 'false',
 				'MMhideQuitButton': 'false',
 				},

--- a/frontend/chromium_manager.py
+++ b/frontend/chromium_manager.py
@@ -76,6 +76,7 @@ def get_builtin_chromium_options(
     user_data_dir: str = "<temp profile dir>",
     mute_audio: bool = False,
     include_default_options: bool = True,
+    exclude_options=None,
 ) -> list[str]:
     """Return VPinFE-managed Chromium flags without the executable path."""
     x = getattr(monitor, "x", "<x>")
@@ -90,7 +91,11 @@ def get_builtin_chromium_options(
         f"--user-data-dir={user_data_dir}",
     ]
     if include_default_options:
-        options.extend(CHROMIUM_BASE_FLAGS)
+        excluded = {str(opt).split("=")[0] for opt in (exclude_options or [])}
+        options.extend(
+            flag for flag in CHROMIUM_BASE_FLAGS
+            if flag.split("=")[0] not in excluded
+        )
     if mute_audio:
         options.append("--mute-audio")
     return options
@@ -237,6 +242,7 @@ class ChromiumManager:
         mute_audio=False,
         additional_options: str = "",
         include_default_options: bool = True,
+        exclude_options: str = "",
     ):
         """Launch one Chromium instance for a given monitor.
 
@@ -281,6 +287,7 @@ class ChromiumManager:
                 user_data_dir=user_data_dir,
                 mute_audio=mute_audio,
                 include_default_options=include_default_options,
+                exclude_options=parse_additional_chromium_options(exclude_options),
             ),
         ]
         try:
@@ -401,6 +408,7 @@ class ChromiumManager:
                 mute_audio=(window_name != "table"),
                 additional_options=settings.chrome_options,
                 include_default_options=not settings.disable_default_chrome_options,
+                exclude_options=cfg_get(iniconfig, "Settings", "chromeoptionsexclude", ""),
             )
 
         logger.info("Launched %s browser windows", len(self._processes))

--- a/managerui/pages/vpinfe_config.py
+++ b/managerui/pages/vpinfe_config.py
@@ -11,7 +11,7 @@ from common.iniconfig import IniConfig
 from common.dof_service import clear_active_dof_event, find_dof_file, send_dof_event_token
 from common.launcher import build_masked_tableini_path, build_vpx_launch_command
 from common.vpxcollections import VPXCollections
-from frontend.chromium_manager import get_builtin_chromium_options
+from frontend.chromium_manager import get_builtin_chromium_options, parse_additional_chromium_options
 from pathlib import Path
 from managerui.config_fields import is_checkbox_field, sort_input_mapping_keys
 from managerui import config_support
@@ -356,8 +356,32 @@ def render_panel(tab=None):
                 config.config.get('Settings', 'disabledefaultchromeoptions', fallback='false'),
             )
         )
+        exclude_raw = str(
+            getattr(
+                settings_inputs.get('chromeoptionsexclude'),
+                'value',
+                config.config.get('Settings', 'chromeoptionsexclude', fallback=''),
+            )
+            or ''
+        ).strip()
+        additional_raw = str(
+            getattr(
+                settings_inputs.get('chromeoptions'),
+                'value',
+                config.config.get('Settings', 'chromeoptions', fallback=''),
+            )
+            or ''
+        ).strip()
+        try:
+            additional_opts = parse_additional_chromium_options(additional_raw)
+        except ValueError:
+            additional_opts = []
         chrome_options_preview.value = '\n'.join(
-            get_builtin_chromium_options(include_default_options=not disable_defaults)
+            get_builtin_chromium_options(
+                include_default_options=not disable_defaults,
+                exclude_options=parse_additional_chromium_options(exclude_raw),
+            )
+            + additional_opts
         )
 
     def build_config_input(section: str, key: str, value: str):
@@ -474,7 +498,7 @@ def render_panel(tab=None):
             inputs[section][key] = inp
             if (section, key) in launch_preview_keys:
                 inp.on_value_change(lambda _: update_launch_preview())
-            if section == 'Settings' and key == 'disabledefaultchromeoptions':
+            if section == 'Settings' and key == 'chromeoptions':
                 inp.on_value_change(lambda _: update_chrome_options_preview())
 
     def save_config():
@@ -664,7 +688,7 @@ def render_panel(tab=None):
                                     if key in options
                                 ]
                                 chrome_option_keys = [
-                                    key for key in ('disabledefaultchromeoptions', 'chromeoptions')
+                                    key for key in ('disabledefaultchromeoptions', 'chromeoptions', 'chromeoptionsexclude')
                                     if key in options
                                 ]
                                 general_keys = [
@@ -791,23 +815,36 @@ def render_panel(tab=None):
                                                     update_launch_preview()
                                     if chrome_option_keys:
                                         with ui.card().classes('config-side-card w-full p-4'):
-                                            ui.label('Additional Chrome Options').classes('text-lg font-semibold').style('color: var(--ink) !important;')
+                                            ui.label('Chrome Options').classes('text-lg font-semibold').style('color: var(--ink) !important;')
                                             ui.label(
-                                                'Append extra flags to each Chromium or Chrome frontend window.'
+                                                'Modify the default flags applied to each Chromium or Chrome frontend window.'
                                             ).classes('text-sm').style('color: var(--ink-muted) !important;')
                                             with ui.element('div').classes('config-launch-layout mt-3'):
                                                 with ui.element('div').classes('config-display-column'):
-                                                    if 'disabledefaultchromeoptions' in chrome_option_keys:
-                                                        value = config.config.get(
-                                                            section,
-                                                            'disabledefaultchromeoptions',
-                                                            fallback='false',
-                                                        )
-                                                        build_config_input(section, 'disabledefaultchromeoptions', value)
                                                     value = config.config.get(section, 'chromeoptions', fallback='')
                                                     build_config_input(section, 'chromeoptions', value)
+                                                    if 'disabledefaultchromeoptions' in chrome_option_keys:
+                                                        with ui.element('div').classes('config-field-card'):
+                                                            ui.label('Disabled Default Options').classes('config-field-label')
+                                                            disable_all_inp = ui.checkbox(
+                                                                text='Disable All',
+                                                                value=(config.config.get(section, 'disabledefaultchromeoptions', fallback='false') == 'true'),
+                                                            ).classes('config-input')
+                                                            exclude_inp = ui.textarea(
+                                                                value=config.config.get(section, 'chromeoptionsexclude', fallback=''),
+                                                                placeholder='--kiosk\n--start-maximized'
+                                                            ).props('outlined autogrow').classes('config-input config-input-env')
+                                                            inputs.setdefault(section, {})['disabledefaultchromeoptions'] = disable_all_inp
+                                                            inputs[section]['chromeoptionsexclude'] = exclude_inp
+
+                                                            def _sync_exclude_enabled():
+                                                                (exclude_inp.disable if bool(disable_all_inp.value) else exclude_inp.enable)()
+
+                                                            _sync_exclude_enabled()
+                                                            disable_all_inp.on_value_change(lambda _: (_sync_exclude_enabled(), update_chrome_options_preview()))
+                                                            exclude_inp.on_value_change(lambda _: update_chrome_options_preview())
                                                 with ui.element('div').classes('config-launch-preview-box'):
-                                                    ui.label('VPinFE-managed Chrome options').classes('text-sm font-semibold').style('color: var(--ink-muted) !important;')
+                                                    ui.label('Effective Chrome Options').classes('text-sm font-semibold').style('color: var(--ink-muted) !important;')
                                                     chrome_options_preview = ui.textarea(
                                                         value='',
                                                     ).props('readonly outlined autogrow').classes('w-full').style(


### PR DESCRIPTION
Chromium behaves a little differently on every distro, compositor, and GPU stack, and the config currently gives users two levers for dealing with that: `chromeoptions` can add flags, and `disabledefaultchromeoptions` throws out the whole default set — including the backgrounding/throttling disables most setups want to keep. This adds the missing third lever: `chromeoptionsexclude`, a per-flag exclusion list, so a user can turn off a single default that misbehaves in their environment without giving up the rest.

What sent me here: on sway (wlroots), the default `--kiosk` flag re-asserts fullscreen around table launch; a fullscreen FE window occludes VPX's windows on that screen, Wayland compositors stop sending frame callbacks to occluded surfaces, and VPX's render loop blocks waiting on them — total render freeze with the ROM still running. That render-loop behavior looks like a VPX bug and I'll report it to vpinball separately, but excluding `--kiosk` removes the trigger — and since sway tiles the windows to fill each screen anyway, the result looks identical to kiosk mode. `chromeoptionsexclude = --kiosk` has my cab (Debian 13, sway 1.10, three screens, portrait playfield) running clean.

The change:
- New `[Settings] chromeoptionsexclude` key, parsed the same way as `chromeoptions` (space/newline/semicolon separated). Matching is on the flag name, so excluding `--disable-features` drops that default regardless of its `=value`.
- Applied in `get_builtin_chromium_options()`, threaded through `launch_window()` like the existing options.
- ManagerUI: the section is now titled "Chrome Options" — "Additional Chrome Options" first, then a "Disabled Default Options" card: the existing `disabledefaultchromeoptions` as a "Disable All" checkbox, plus the new per-flag box, greyed out when Disable All is on. The effective-options preview reflects exclusions and additions live.

No impact on existing behavior: the key defaults to empty, the built-in flag list and the per-OS handling already in the code are untouched, and nothing changes for anyone who doesn't set it.

Happy to adjust the key name or split off the UI changes if you'd rather take the knob alone.