### PR TITLE
Drag and drop imports for the manager UI

### DIFF
--- a/common/config_access.py
+++ b/common/config_access.py
@@ -44,6 +44,7 @@ class SettingsConfig:
     table_root_dir: str = ""
     vpx_bin_path: str = ""
     vpx_ini_path: str = ""
+    rar_tool_path: str = ""
     vpx_log_delete_on_start: bool = False
     theme: str = "Revolution"
     startup_collection: str = ""
@@ -66,6 +67,7 @@ class SettingsConfig:
             table_root_dir=cfg_get(source, "Settings", "tablerootdir", "").strip(),
             vpx_bin_path=cfg_get(source, "Settings", "vpxbinpath", "").strip(),
             vpx_ini_path=cfg_get(source, "Settings", "vpxinipath", "").strip(),
+            rar_tool_path=cfg_get(source, "Settings", "rartoolpath", "").strip(),
             vpx_log_delete_on_start=cfg_bool(source, "Settings", "vpxlogdeleteonstart", False),
             theme=theme,
             startup_collection=cfg_get(source, "Settings", "startup_collection", "").strip(),

--- a/common/iniconfig.py
+++ b/common/iniconfig.py
@@ -35,6 +35,7 @@ class IniConfig:
 				'globaltableinioverridemask': '',
 				'tablerootdir': '',
 				'vpxinipath': '',
+				'rartoolpath': '',
 				'vpxlogdeleteonstart': 'false',
 				'theme': 'Revolution',
 				'startup_collection': '',

--- a/main.py
+++ b/main.py
@@ -167,6 +167,10 @@ except Exception:
 _start_startup_media_sync()
 start_dof_service_if_enabled(iniconfig)
 
+# Point the archive analyzer at a configured RAR tool (blank = auto-detect from PATH)
+from managerui.services.asset_analyzer_service import configure_rar_tool
+configure_rar_tool(iniconfig.config.get('Settings', 'rartoolpath', fallback='').strip())
+
 # Create API instances and register with WebSocket bridge
 create_api_instances()
 

--- a/managerui/managerui.py
+++ b/managerui/managerui.py
@@ -24,6 +24,7 @@ from .page_registry import NAV_PAGES, PAGE_ALIASES
 from .services import app_control
 from .services.archive_service import cleanup_archive, create_vpxz_archive
 from .ui_helpers import load_manager_styles, nav_button
+from . import upload_api
 import asyncio
 import threading
 import os
@@ -385,6 +386,10 @@ def remote_page():
 def mobile_page():
     load_manager_styles()
     tab_mobile.build()
+
+
+# Asset upload/import API — routes defined in their own module.
+upload_api.register_routes(app)
 
 
 # API endpoint for remote launch state (polled by frontend themes)

--- a/managerui/pages/dnd_drop_zone.py
+++ b/managerui/pages/dnd_drop_zone.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+from uuid import uuid4
+
+from nicegui import context, run, ui
+
+from managerui.pages.import_confirm_dialog import open_import_confirm_dialog
+from managerui.services import upload_session_service
+from managerui.services.asset_analyzer_service import AnalysisResult, analyze_upload_session
+from managerui.services.asset_import_service import build_import_plan, build_media_slot_plan
+
+
+logger = logging.getLogger("vpinfe.manager.dnd_ui")
+
+_script_clients: set[str] = set()
+
+
+@dataclass(frozen=True)
+class DropContext:
+    table_path: str = ""
+    table_row: dict | None = None
+    rom_name: str = ""
+    allow_new_table: bool = False
+
+
+_STATIC_DIR = Path(__file__).resolve().parent.parent / "static"
+
+
+def _asset_version(filename: str) -> int:
+    """File mtime as a cache-busting query value, so browsers pick up updated assets."""
+    try:
+        return int((_STATIC_DIR / filename).stat().st_mtime)
+    except OSError:
+        return 0
+
+
+def _ensure_assets() -> None:
+    ui.add_head_html(
+        f'<link rel="stylesheet" href="/static/dnd_upload.css?v={_asset_version("dnd_upload.css")}">')
+    client_id = context.client.id
+    if client_id not in _script_clients:
+        ui.add_head_html(
+            f'<script src="/static/dnd_upload.js?v={_asset_version("dnd_upload.js")}"></script>')
+        _script_clients.add(client_id)
+
+
+def create_drop_zone(*, label: str, get_context: Callable[[], DropContext],
+                     on_imported: Callable[[dict], None] | None = None,
+                     visible: bool = True) -> ui.element:
+    """Render a drag/drop target that analyzes dropped assets and opens an import dialog.
+
+    With visible=False the zone renders hidden and only hosts the event plumbing —
+    used by pages whose real drop targets are rows or cells (see enable_row_drops /
+    enable_cell_drops).
+    """
+    _ensure_assets()
+    token = uuid4().hex[:12]
+    state = {"busy": False, "client": context.client}
+
+    zone = ui.element("div").classes(f"dnd-drop-zone vpinfe-dnd-{token}")
+    if not visible:
+        zone.style("display: none;")
+    with zone:
+        ui.icon("cloud_upload").classes("dnd-drop-zone__icon")
+        status_label = ui.label(label).style("color: inherit;")
+
+    async def handle_done(upload_id: str, display_name: str, row_key: str = "",
+                          cell_row: str = "", cell_media_key: str = "") -> None:
+        if state["busy"]:
+            return
+        state["busy"] = True
+        client = state["client"]
+        try:
+            session_dir = upload_session_service.get_session_dir(upload_id)
+
+            cell_resolver = state.get("resolve_cell")
+            if cell_row and cell_media_key and cell_resolver is not None:
+                # Slot-targeted drop: the cell dictates table and media key; no analysis.
+                table_path = cell_resolver(cell_row)
+                files = [p for p in session_dir.iterdir() if p.is_file()]
+                dirs = [p for p in session_dir.iterdir() if p.is_dir()]
+                with client:
+                    if not table_path:
+                        ui.notify("Could not resolve the drop target table", type="negative")
+                        upload_session_service.cleanup_session(upload_id)
+                        return
+                    if dirs or len(files) != 1:
+                        ui.notify("Drop a single media file on a slot", type="warning")
+                        upload_session_service.cleanup_session(upload_id)
+                        return
+                    plan = build_media_slot_plan(files[0], table_path=table_path,
+                                                 media_key=cell_media_key)
+                    if not plan.items:
+                        reasons = "; ".join(sorted({b.reason for b in plan.blocked})) or "Nothing to import"
+                        ui.notify(reasons, type="warning")
+                        upload_session_service.cleanup_session(upload_id)
+                        return
+                    cell_analysis = AnalysisResult("file", files[0].name, (), False)
+                    open_import_confirm_dialog(cell_analysis, plan, files[0], upload_id,
+                                               on_imported, refresh_media_cache=False)
+                return
+
+            analysis, source_path = await run.io_bound(analyze_upload_session, session_dir)
+            resolver = state.get("resolve_row")
+            if row_key and resolver is not None:
+                # A drop on a row targets that row's table, regardless of selection.
+                ctx = resolver(row_key)
+                if ctx is None:
+                    with client:
+                        ui.notify("Could not resolve the drop target table", type="negative")
+                    upload_session_service.cleanup_session(upload_id)
+                    return
+            else:
+                ctx = get_context()
+            with client:
+                status_label.set_text(label)
+                if analysis.error:
+                    ui.notify(f"Could not import: {analysis.error}", type="negative")
+                    upload_session_service.cleanup_session(upload_id)
+                    return
+                plan = build_import_plan(
+                    analysis,
+                    table_path=ctx.table_path,
+                    table_row=ctx.table_row,
+                    rom_name=ctx.rom_name,
+                    allow_new_table=ctx.allow_new_table,
+                )
+                if not plan.items:
+                    reasons = "; ".join(sorted({b.reason for b in plan.blocked})) or "Nothing to import"
+                    ui.notify(reasons, type="warning")
+                    upload_session_service.cleanup_session(upload_id)
+                    return
+                open_import_confirm_dialog(analysis, plan, source_path, upload_id, on_imported,
+                                           display_name=display_name)
+        except Exception:
+            logger.exception("Drag/drop analysis failed")
+            with client:
+                ui.notify("Drag/drop analysis failed", type="negative")
+            upload_session_service.cleanup_session(upload_id)
+        finally:
+            state["busy"] = False
+
+    def on_event(event) -> None:
+        payload = event.args or {}
+        if payload.get("token") != token:
+            return
+        status = payload.get("status")
+        if status == "progress":
+            total = payload.get("total") or 0
+            done = payload.get("done") or 0
+            name = payload.get("name") or ""
+            if total:
+                status_label.set_text(f"Uploading {done}/{total}… {name}")
+        elif status == "done":
+            asyncio.create_task(handle_done(payload.get("upload_id"), payload.get("name") or "",
+                                            payload.get("row_key") or "",
+                                            payload.get("cell_row") or "",
+                                            payload.get("cell_media_key") or ""))
+        elif status == "error":
+            status_label.set_text(label)
+            ui.notify(f"Upload failed: {payload.get('message', '')}", type="negative")
+
+    ui.on("vpinfe_dnd", on_event)
+    # The static script auto-attaches drop zones via a MutationObserver, so no
+    # server-side timer is needed (and none can outlive a client reconnect).
+    zone.dnd_token = token
+    zone.dnd_state = state
+    return zone
+
+
+def enable_row_drops(zone: ui.element, container: ui.element,
+                     resolve_row_context: Callable[[str], DropContext | None]) -> None:
+    """Make rows inside container individual drop targets for an existing zone.
+
+    Rows must carry a data-drop-filename attribute; a drop on a row resolves its
+    DropContext via resolve_row_context (the row under the cursor always wins over
+    any checked selection).
+    """
+    zone.dnd_state["resolve_row"] = resolve_row_context
+    container.classes(f"vpinfe-dnd-rows-{zone.dnd_token}")
+
+
+def enable_cell_drops(zone: ui.element, container: ui.element,
+                      resolve_table_path: Callable[[str], str | None]) -> None:
+    """Make media cells inside container slot-targeted drop targets.
+
+    Cells must carry data-drop-media-key and data-drop-media-row attributes; the cell
+    dictates both the target table (resolved via resolve_table_path) and the media slot.
+    """
+    zone.dnd_state["resolve_cell"] = resolve_table_path
+    container.classes(f"vpinfe-dnd-cells-{zone.dnd_token}")

--- a/managerui/pages/import_confirm_dialog.py
+++ b/managerui/pages/import_confirm_dialog.py
@@ -1,0 +1,351 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import Callable
+
+from nicegui import context, run, ui
+
+from managerui.services import table_service, upload_session_service
+from managerui.services.asset_analyzer_service import AnalysisResult
+from managerui.services.asset_import_service import (
+    ImportPlan,
+    execute_import_plan,
+    find_vps_entry,
+    select_plan_items,
+    vps_folder_name,
+)
+from managerui.services.asset_registry import spec_for
+from managerui.services.media_service import MEDIA_TYPES, invalidate_media_cache
+from managerui.ui_helpers import debounced_input, dialog_card
+
+
+logger = logging.getLogger("vpinfe.manager.dnd_ui")
+
+_MEDIA_LABELS = {key: label for key, label, _ in MEDIA_TYPES}
+
+_CHIP_STYLE = ("font-size: 11px; letter-spacing: 0.04em; color: var(--neon-purple); "
+               "border: 1px solid var(--line); border-radius: 10px; padding: 1px 6px; "
+               "width: 112px; text-align: center; flex: none; overflow: hidden; "
+               "text-overflow: ellipsis; white-space: nowrap;")
+
+
+def _chip_label(asset) -> str:
+    if asset.kind != "media":
+        return spec_for(asset.kind).label
+    label = _MEDIA_LABELS.get(asset.media_key, asset.media_key)
+    if asset.media_key == "audio" or "Video" in label:
+        return label
+    return f"{label} image"
+
+
+def _vps_search_term(name: str) -> str:
+    """Reduce a vpx-derived name to a searchable VPS term (drop parenthetical/version tail)."""
+    term = (name or "").split("(")[0].strip()
+    return term or (name or "").strip()
+
+
+def _human_size(num_bytes: int) -> str:
+    size = float(num_bytes)
+    for unit in ("B", "KB", "MB", "GB"):
+        if size < 1024 or unit == "GB":
+            return f"{size:.0f} {unit}" if unit == "B" else f"{size:.1f} {unit}"
+        size /= 1024
+    return f"{size:.1f} GB"
+
+
+def open_import_confirm_dialog(analysis: AnalysisResult, plan: ImportPlan, source_path: Path,
+                               upload_id: str, on_imported: Callable[[dict], None] | None,
+                               display_name: str = "", refresh_media_cache: bool = True) -> None:
+    """Confirm and execute an import plan, showing detected assets and their destinations."""
+    state = {"busy": False, "client": context.client}
+    checks: dict[int, ui.checkbox] = {}
+    name_input = None
+    vps_state = {"entry": None, "name_dirty": False, "last_set": ""}
+    title_source = display_name or analysis.source_name
+    single = len(plan.items) == 1 and not plan.blocked
+
+    def _row_primary(item) -> str:
+        entries = [e for e in item.asset.entries if not e.is_dir]
+        if len(entries) == 1:
+            return Path(entries[0].arcname).name
+        return f"{len(entries)} files"
+
+    def _row_destination(item) -> str:
+        # Relative to the table folder; the folder itself is stated by the title/name field.
+        base = Path(plan.table_path)
+        dest = Path(item.destination)
+        try:
+            rel = dest.relative_to(base)
+        except ValueError:
+            return item.destination
+        if item.action == "extract_tree":
+            return f"{rel.as_posix()}/"
+        if item.action == "replace_media":
+            return rel.as_posix()   # canonical name is the point (wheel.png, bg.mp4, ...)
+        if str(rel.parent) == ".":
+            return "table folder root"
+        if rel.name == _row_primary(item):
+            return f"{rel.parent.as_posix()}/"
+        return rel.as_posix()
+
+    def _replace_note(item) -> str:
+        if item.action == "write_info":
+            if plan.new_table_dir_name:
+                return "adopts bundle metadata"
+            if Path(plan.table_path, f"{Path(plan.table_path).name}.info").exists():
+                return "merges into existing metadata — fills gaps only · backup kept"
+            return "adopts bundle metadata"
+        if plan.new_table_dir_name:
+            return ""   # brand-new folder; nothing can be replaced
+        base = Path(plan.table_path)
+        if item.action == "replace_vpx":
+            existing = sorted(base.glob("*.vpx"))
+            if existing:
+                return f"replaces {existing[0].name}"
+            return ""
+        if item.action == "replace_media":
+            return "replaces current" if Path(item.destination).exists() else "slot is empty"
+        if item.action in {"replace_b2s", "copy"} and Path(item.destination).exists():
+            return "replaces existing file"
+        return ""
+
+    dlg = ui.dialog().props("persistent")
+    with dlg, dialog_card("640px"):
+        if plan.new_table_dir_name:
+            ui.label(f"Import from {title_source}").classes("text-lg font-bold").style("color: var(--ink);")
+            ui.label("Files keep their names — only the folder is named here").classes(
+                "text-xs").style("color: var(--ink-muted);")
+        else:
+            ui.label(f"Import to {Path(plan.table_path).name}").classes("text-lg font-bold").style("color: var(--ink);")
+            if not single:
+                ui.label(f"from {title_source}").classes("text-xs").style("color: var(--ink-muted);")
+
+        if plan.new_table_dir_name:
+            name_input = ui.input("New table folder", value=plan.new_table_dir_name).props("outlined dense").classes("w-full")
+
+            def _on_name_edit(e) -> None:
+                value = e.args if isinstance(e.args, str) else name_input.value
+                # set_value round-trips through the client, so compare against the
+                # last programmatic value instead of using a synchronous flag.
+                if value != vps_state.get("last_set"):
+                    vps_state["name_dirty"] = True
+
+            vps_state["last_set"] = plan.new_table_dir_name
+            name_input.on("update:model-value", _on_name_edit)
+
+            with ui.row().classes("items-center gap-2 w-full no-wrap"):
+                ui.icon("travel_explore").style("color: var(--neon-purple);")
+                vps_label = ui.label("No VPS association — naming from file").style("color: var(--ink-muted);")
+                vps_label.tooltip("Link this table to its Virtual Pinball Spreadsheet entry to name the "
+                                  "folder canonically and download its media and metadata.")
+                ui.space()
+                vps_change_btn = ui.button("Search VPS").props("flat dense").style("color: var(--neon-cyan);")
+                vps_clear_btn = ui.button(icon="close").props("flat dense round").style("color: var(--ink-muted);")
+                vps_clear_btn.visible = False
+
+            def _set_name(value: str) -> None:
+                vps_state["last_set"] = value
+                name_input.set_value(value)
+
+            def _set_association(entry: dict | None) -> None:
+                vps_state["entry"] = entry
+                if entry is None:
+                    vps_label.set_text("No VPS association — naming from file")
+                    vps_label.style("color: var(--ink-muted);")
+                    vps_clear_btn.visible = False
+                    if not vps_state["name_dirty"]:
+                        _set_name(plan.new_table_dir_name)
+                    return
+                label = vps_folder_name(entry) or entry.get("name", "")
+                vps_label.set_text(f"VPS: {label}")
+                vps_label.style("color: var(--ink);")
+                vps_clear_btn.visible = True
+                if not vps_state["name_dirty"]:
+                    _set_name(vps_folder_name(entry))
+
+            def _open_vps_picker() -> None:
+                picker = ui.dialog()
+                with picker, dialog_card("560px"):
+                    ui.label("Select VPS entry").classes("text-lg font-bold").style("color: var(--ink);")
+                    search_input = ui.input("Search", value=_vps_search_term(plan.new_table_dir_name)).props(
+                        "outlined dense clearable").classes("w-full")
+                    results_column = ui.column().classes("w-full gap-1").style("max-height: 320px; overflow-y: auto;")
+
+                    def _render_results(entries: list[dict]) -> None:
+                        results_column.clear()
+                        with results_column:
+                            if not entries:
+                                ui.label("No matches").classes("text-sm").style("color: var(--ink-muted);")
+                            for entry in entries:
+                                def _choose(entry=entry) -> None:
+                                    _set_association(entry)
+                                    picker.close()
+                                label = f"{entry.get('name', '')} ({entry.get('manufacturer', '?')} {entry.get('year', '?')})"
+                                ui.button(label, on_click=_choose).props("flat align=left no-caps").classes(
+                                    "w-full").style("color: var(--ink);")
+
+                    async def _do_search() -> None:
+                        entries = await run.io_bound(table_service.search_vpsdb, search_input.value or "", 20)
+                        _render_results(entries)
+
+                    debounced_input(search_input, 300)
+                    search_input.on("update:model-value", lambda _e: asyncio.create_task(_do_search()))
+                    asyncio.create_task(_do_search())
+                picker.open()
+
+            vps_change_btn.on_click(_open_vps_picker)
+            vps_clear_btn.on_click(lambda: _set_association(None))
+
+            async def _auto_associate() -> None:
+                # A bundle .info with a resolvable VPS id is more authoritative than
+                # filename guessing — seed the association from it and stop there.
+                bundle_vps_id = ((analysis.bundle_info or {}).get("Info") or {}).get("VPSId", "")
+                if bundle_vps_id:
+                    entry = await run.io_bound(find_vps_entry, str(bundle_vps_id))
+                    if entry is not None:
+                        if vps_state["entry"] is None:
+                            with state["client"]:
+                                _set_association(entry)
+                        return
+                term = _vps_search_term(plan.new_table_dir_name)
+                if not term:
+                    return
+                # vpx names often carry author/version tails ("Medieval Madness VPW v2"),
+                # so retry with trailing words dropped until something matches.
+                words = term.split()
+                for count in range(len(words), 0, -1):
+                    candidate = " ".join(words[:count])
+                    entries = await run.io_bound(table_service.search_vpsdb, candidate, 5)
+                    if entries:
+                        if vps_state["entry"] is None:
+                            with state["client"]:
+                                _set_association(entries[0])
+                        return
+
+            asyncio.create_task(_auto_associate())
+
+        with ui.column().classes("w-full gap-0 q-mt-sm"):
+            for index, item in enumerate(plan.items):
+                with ui.row().classes("items-center gap-2 w-full no-wrap").style(
+                        "border-top: 1px solid var(--line); padding: 6px 0; min-width: 0;"):
+                    if not single:
+                        checks[index] = ui.checkbox(value=item.default_enabled).props("dense")
+                    ui.label(_chip_label(item.asset)).style(_CHIP_STYLE)
+                    with ui.column().classes("gap-0").style("flex: 1; min-width: 0;"):
+                        ui.label(_row_primary(item)).classes("w-full truncate").style("color: var(--ink);")
+                        note = _replace_note(item)
+                        dest_text = f"→ {_row_destination(item)}" + (f"  ·  {note}" if note else "")
+                        ui.label(dest_text).classes("text-xs w-full truncate").style(
+                            "color: var(--ink-muted); font-family: monospace;")
+                    if item.asset.size:
+                        ui.label(_human_size(item.asset.size)).classes("text-xs").style(
+                            "color: var(--ink-muted); flex: none;")
+
+            for blocked in plan.blocked:
+                with ui.row().classes("items-center gap-2 w-full no-wrap").style(
+                        "border-top: 1px solid var(--line); padding: 6px 0; min-width: 0; opacity: 0.55;"):
+                    ui.icon("block").style("color: var(--ink-muted); flex: none;")
+                    ui.label(_chip_label(blocked.asset)).style(_CHIP_STYLE)
+                    with ui.column().classes("gap-0").style("flex: 1; min-width: 0;"):
+                        ui.label(_row_primary(blocked)).classes("w-full truncate").style("color: var(--ink-muted);")
+                        ui.label(blocked.reason).classes("text-xs w-full truncate").style("color: var(--ink-muted);")
+
+        for note in analysis.notes:
+            ui.label(note).classes("text-xs").style("color: var(--ink-muted);")
+
+        if analysis.unrecognized:
+            count = len(analysis.unrecognized)
+            with ui.expansion(f"{count} file{'s' if count != 1 else ''} won't be imported").props(
+                    "dense").classes("w-full").style("color: var(--ink-muted); font-size: 13px;"):
+                with ui.column().classes("gap-0 pl-4").style("max-height: 140px; overflow-y: auto;"):
+                    for name in analysis.unrecognized:
+                        ui.label(name).classes("text-xs").style(
+                            "color: var(--ink-muted); font-family: monospace;")
+
+        loading_overlay = ui.element("div").style(
+            "position: absolute; top: 0; left: 0; right: 0; bottom: 0; "
+            "background: var(--bg); opacity: 0.9; z-index: 1000; "
+            "display: none; flex-direction: column; align-items: center; justify-content: center;"
+        )
+        with loading_overlay:
+            with ui.column().classes("items-center justify-center gap-4 w-full"):
+                ui.spinner("dots", size="xl", color="purple")
+                loading_label = ui.label("Importing...").classes("text-lg text-center").style("color: var(--ink);")
+
+        ui.separator()
+        with ui.row().classes("justify-end gap-2 w-full"):
+            def _cancel() -> None:
+                dlg.close()
+                upload_session_service.cleanup_session(upload_id)
+
+            ui.button("Cancel", on_click=_cancel).props("flat").style("color: var(--ink-muted);")
+
+            def _import_label() -> str:
+                if single:
+                    return "Import"
+                count = sum(1 for check in checks.values() if check.value)
+                return f"Import {count} item{'s' if count != 1 else ''}"
+
+            import_btn = ui.button(_import_label(), icon="download").style(
+                "color: var(--neon-cyan) !important; background: var(--surface) !important; "
+                "border: 1px solid var(--neon-cyan) !important; border-radius: 18px; padding: 4px 10px;"
+            )
+            for check in checks.values():
+                check.on_value_change(lambda _e: import_btn.set_text(_import_label()))
+
+    def _resolved_plan() -> ImportPlan:
+        indices = None if single else [index for index in range(len(plan.items)) if checks[index].value]
+        new_name = name_input.value if name_input else None
+        return select_plan_items(plan, indices, new_name)
+
+    async def do_import() -> None:
+        if state["busy"]:
+            return
+        if not single and not any(check.value for check in checks.values()):
+            ui.notify("Select at least one item to import", type="warning")
+            return
+        state["busy"] = True
+        client = state["client"]
+        with client:
+            loading_overlay.style(add="display: flex;", remove="display: none;")
+            loading_label.set_text("Importing...")
+            import_btn.disable()
+        try:
+            resolved = _resolved_plan()
+            report = await run.io_bound(execute_import_plan, resolved, source_path)
+            vps_entry = vps_state["entry"]
+            if vps_entry is not None and report.get("new_table"):
+                with client:
+                    loading_label.set_text("Associating with VPS and downloading media...")
+                try:
+                    await run.io_bound(table_service.associate_vps_to_folder,
+                                       Path(report["table_path"]), vps_entry, True)
+                    await run.io_bound(table_service.build_metadata, downloadMedia=True,
+                                       updateAll=True, tableName=resolved.new_table_dir_name)
+                except Exception:
+                    # The files are already imported; a failed association must not read as a failed import.
+                    logger.exception("VPS association failed after import")
+                    with client:
+                        ui.notify("Imported, but VPS association failed", type="warning")
+            with client:
+                if refresh_media_cache:
+                    invalidate_media_cache()
+                ui.notify(f"Imported {len(report['imported'])} item(s)", type="positive")
+            dlg.close()
+            upload_session_service.cleanup_session(upload_id)
+            if on_imported:
+                on_imported(report)
+        except Exception as ex:
+            logger.exception("Import failed")
+            with client:
+                ui.notify(f"Import failed: {ex}", type="negative")
+        finally:
+            state["busy"] = False
+            with client:
+                loading_overlay.style(add="display: none;", remove="display: flex;")
+                import_btn.enable()
+
+    import_btn.on_click(lambda: asyncio.create_task(do_import()))
+    dlg.open()

--- a/managerui/pages/media.py
+++ b/managerui/pages/media.py
@@ -6,6 +6,7 @@ from nicegui import ui, events, run, app, context
 from typing import List, Dict, Optional
 
 from managerui.filters import apply_table_filters, build_table_filter_options
+from managerui.pages.dnd_drop_zone import create_drop_zone, enable_cell_drops, DropContext
 from managerui.services import media_service
 from managerui.ui_helpers import debounced_input, load_page_style
 
@@ -550,9 +551,11 @@ def render_panel():
                 is_video = media_filename.endswith('.mp4')
                 is_audio = media_filename.endswith('.mp3')
 
+                cell_td = ('<q-td :props="props" data-drop-media-key="' + media_key
+                           + '" :data-drop-media-row="props.row.table_dir">')
+
                 if is_audio:
-                    media_table.add_slot(f'body-cell-{col_name}', '''
-                        <q-td :props="props">
+                    media_table.add_slot(f'body-cell-{col_name}', cell_td + '''
                             <div v-if="props.row.media.''' + media_key + '''"
                                  @click.stop="''' + emit_expr + '''"
                                  style="cursor: pointer;">
@@ -565,8 +568,7 @@ def render_panel():
                         </q-td>
                     ''')
                 elif is_video:
-                    media_table.add_slot(f'body-cell-{col_name}', '''
-                        <q-td :props="props">
+                    media_table.add_slot(f'body-cell-{col_name}', cell_td + '''
                             <div v-if="props.row.media.''' + media_key + '''" class="media-thumb-wrapper"
                                  @click.stop="''' + emit_expr + '''"
                                  style="cursor: pointer;">
@@ -590,8 +592,7 @@ def render_panel():
                         </q-td>
                     ''')
                 else:
-                    media_table.add_slot(f'body-cell-{col_name}', '''
-                        <q-td :props="props">
+                    media_table.add_slot(f'body-cell-{col_name}', cell_td + '''
                             <div v-if="props.row.media.''' + media_key + '''" class="media-thumb-wrapper"
                                  @click.stop="''' + emit_expr + '''"
                                  style="cursor: pointer;">
@@ -632,6 +633,31 @@ def render_panel():
                     media_label=media_label,
                 )
             media_table.on('media_click', on_media_click)
+
+            def _cell_table_path(table_dir: str):
+                return next((r.get('table_path') for r in (_media_cache() or [])
+                             if r.get('table_dir') == table_dir), None)
+
+            def _on_cell_imported(report):
+                async def _refresh():
+                    table_path = report.get('table_path', '')
+                    table_dir = os.path.basename(table_path.rstrip('/'))
+                    for media_key in report.get('media_keys', []):
+                        target_filename = MEDIA_KEY_TO_FILENAME[media_key]
+                        target_path = os.path.join(table_path, 'medias', target_filename)
+                        new_url = media_service.media_url('media_tables', table_dir, 'medias', target_filename)
+                        new_thumb = await run.io_bound(media_service.ensure_thumb, table_dir, media_key, target_path)
+                        media_service.update_cache_entry(table_dir, media_key, new_url, new_thumb)
+                    update_table_display()
+                asyncio.create_task(_refresh())
+
+            media_drop_zone = create_drop_zone(
+                label='',
+                get_context=lambda: DropContext(),
+                on_imported=_on_cell_imported,
+                visible=False,
+            )
+            enable_cell_drops(media_drop_zone, media_table, _cell_table_path)
 
             media_table.add_slot('bottom', '''
                 <div class="row full-width items-center q-pa-sm"

--- a/managerui/pages/table_detail_dialog.py
+++ b/managerui/pages/table_detail_dialog.py
@@ -12,6 +12,7 @@ from typing import Callable, Optional
 from nicegui import context, events, run, ui
 
 from managerui.pages.table_dialog_context import TableDialogContext, default_context
+from managerui.pages.dnd_drop_zone import create_drop_zone, DropContext
 from managerui.services import plugin_profile_service, table_index_service, table_service
 from managerui.services.media_service import invalidate_media_cache
 from managerui.ui_helpers import load_page_style
@@ -701,6 +702,13 @@ def _render_table_dialog(row_data: dict, on_close: Optional[Callable[[], None]] 
                 rom_name = (row_data.get('rom') or '').strip()
 
                 with ui.column().classes('gap-4 p-2').style('background: var(--surface); border-radius: 8px;'):
+                    create_drop_zone(
+                        label='Drop asset files or archives for this table',
+                        get_context=lambda: DropContext(table_path=str(table_path), table_row=row_data,
+                                                        rom_name=rom_name),
+                        on_imported=lambda _report: (on_close() if on_close else None),
+                    )
+
                     # Pupvideos uploader (zip file)
                     with ui.row().classes('addon-card w-full items-center justify-between'):
                         with ui.row().classes('items-center gap-3'):

--- a/managerui/pages/tables.py
+++ b/managerui/pages/tables.py
@@ -10,6 +10,7 @@ from managerui.filters import apply_table_filters, build_table_filter_options
 from managerui.paths import VPINFE_INI_PATH, get_tables_path as resolve_tables_path
 from managerui.pages.table_detail_dialog import open_table_dialog
 from managerui.pages.table_import_dialog import open_import_table_dialog
+from managerui.pages.dnd_drop_zone import create_drop_zone, enable_row_drops, DropContext
 from managerui.pages.table_match_dialog import open_match_vps_dialog, open_missing_tables_dialog
 from managerui.services import table_service
 from managerui.services import table_index_service
@@ -598,6 +599,27 @@ def render_panel(tab=None):
 
                     import_btn.on_click(lambda: open_import_table_dialog(perform_scan))
 
+        def _dnd_context() -> DropContext:
+            selected = table.selected or []
+            if len(selected) == 1:
+                row = selected[0]
+                return DropContext(table_path=row.get('table_path', ''), table_row=row,
+                                   rom_name=(row.get('rom') or '').strip(), allow_new_table=True)
+            return DropContext(allow_new_table=True)
+
+        def _dnd_row_context(row_key: str) -> DropContext | None:
+            row = next((r for r in (_tables_cache() or []) if r.get('filename') == row_key), None)
+            if not row:
+                return None
+            return DropContext(table_path=row.get('table_path', ''), table_row=row,
+                               rom_name=(row.get('rom') or '').strip())
+
+        drop_zone = create_drop_zone(
+            label='Drop a table archive, folder, or asset file here to import',
+            get_context=_dnd_context,
+            on_imported=lambda _report: asyncio.create_task(perform_scan(silent=True)),
+        )
+
         # Use cached data if available, otherwise start with empty
         initial_rows = _tables_cache() if _tables_cache() is not None else []
         initial_missing = _missing_cache() if _missing_cache() is not None else []
@@ -780,7 +802,7 @@ def render_panel(tab=None):
             )
             # Add custom slot for name column to include status badges, links, and collections
             table.add_slot('body-cell-name', '''
-                <q-td :props="props">
+                <q-td :props="props" :data-drop-filename="props.row.filename">
                     <div style="display: flex; flex-direction: column; gap: 4px;">
                         <div style="display: flex; align-items: center; gap: 8px;">
                             <span style="font-size: 1.08rem; font-weight: 600; line-height: 1.25; color: var(--ink);">{{ props.value }}</span>
@@ -912,6 +934,8 @@ def render_panel(tab=None):
                     <q-btn flat round dense icon="last_page" :disable="props.isLastPage" @click="props.lastPage" size="sm" style="color: var(--ink-muted);" />
                 </div>
             ''')
+
+            enable_row_drops(drop_zone, table, _dnd_row_context)
 
         # Wire up batch add-to-collection button
         def on_batch_add():

--- a/managerui/pages/vpinfe_config.py
+++ b/managerui/pages/vpinfe_config.py
@@ -62,6 +62,7 @@ FRIENDLY_NAMES = {
     'globaltableinioverrideenabled': 'Global tableini Override Enabled',
     'globaltableinioverridemask': 'Global tableini Override Mask',
     'vpxinipath' : 'VPX Ini Path',
+    'rartoolpath': 'RAR Tool Path (unar/unrar, blank = auto-detect)',
     'vpxlogdeleteonstart': 'Delete VPinball Log On Table Start',
     'tablerootdir': 'Tables Directory',
     'startup_collection': 'Startup Collection',

--- a/managerui/services/asset_analyzer_service.py
+++ b/managerui/services/asset_analyzer_service.py
@@ -1,0 +1,665 @@
+from __future__ import annotations
+
+import fnmatch
+import logging
+import os
+import shutil
+import sys
+import tempfile
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Protocol
+
+from managerui.services.asset_registry import (
+    ARCHIVE_EXTENSIONS,
+    match_media_key,
+    spec_for,
+)
+
+try:
+    import rarfile
+except ImportError:  # pragma: no cover - optional dependency
+    rarfile = None
+
+try:
+    import py7zr
+except ImportError:  # pragma: no cover - optional dependency
+    py7zr = None
+
+
+logger = logging.getLogger("vpinfe.manager.asset_analyzer")
+
+_CHUNK = 1024 * 1024
+
+_JUNK_COMPONENTS = {"__macosx", ".ds_store", "thumbs.db", "desktop.ini"}
+_ROM_SUFFIXES = {".bin", ".rom", ".cpu", ".snd", ".dat"}
+_VIDEO_SUFFIXES = {".mp4", ".avi", ".mkv", ".webm"}
+_AUDIO_SUFFIXES = {".mp3", ".ogg", ".wav"}
+_ALTSOUND_MARKERS = {"altsound.csv", "g-sound.csv"}
+_PUP_MARKERS_EXACT = {"screens.pup", "editthispuppack.bat", "scriptonly.txt"}
+_PUP_MARKER_GLOBS = ("*option*.bat", "*screen*.bat")
+_PUP_FALLBACK_MIN_SUBDIRS = 10
+_PUP_FALLBACK_MIN_VIDEOS = 10
+
+
+@dataclass(frozen=True)
+class SourceEntry:
+    path: str        # key within the source, used for extraction
+    arcname: str     # normalized path (wrapper stripped), used for layout and rules
+    size: int
+    is_dir: bool
+
+
+@dataclass(frozen=True)
+class DetectedAsset:
+    kind: str
+    label: str
+    entries: tuple[SourceEntry, ...]
+    root: str = ""          # arcname-space subtree root for folder kinds; "" for file kinds
+    media_key: str = ""
+    size: int = 0
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class AnalysisResult:
+    source_kind: str
+    source_name: str
+    assets: tuple[DetectedAsset, ...]
+    has_table: bool
+    notes: tuple[str, ...] = ()
+    error: str = ""
+    unrecognized: tuple[str, ...] = ()   # source-relative paths that no rule claimed
+    bundle_info: dict | None = None      # parsed .info content when a bundle carries one
+
+
+# --- Source backends -------------------------------------------------------
+
+class AssetSource(Protocol):
+    name: str
+    kind: str
+
+    def entries(self) -> list[SourceEntry]: ...
+    def extract_member(self, entry_path: str, dest: Path) -> None: ...
+    def archive_path(self) -> Path | None: ...
+    def close(self) -> None: ...
+
+
+def _clean_name(raw: str) -> str:
+    name = raw.replace("\\", "/").strip()
+    while name.startswith("/"):
+        name = name[1:]
+    return name.rstrip("/")
+
+
+class ZipSource:
+    def __init__(self, path: Path) -> None:
+        self.name = path.name
+        self.kind = "zip"
+        self._path = path
+        self._zip = zipfile.ZipFile(path)
+        self._raw_by_path: dict[str, str] = {}
+        for info in self._zip.infolist():
+            if info.is_dir():
+                continue
+            cleaned = _clean_name(info.filename)
+            if cleaned:
+                self._raw_by_path.setdefault(cleaned, info.filename)
+
+    def entries(self) -> list[SourceEntry]:
+        out: list[SourceEntry] = []
+        for info in self._zip.infolist():
+            cleaned = _clean_name(info.filename)
+            if not cleaned:
+                continue
+            out.append(SourceEntry(cleaned, cleaned, info.file_size, info.is_dir()))
+        return out
+
+    def extract_member(self, entry_path: str, dest: Path) -> None:
+        raw = self._raw_by_path[entry_path]
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        with self._zip.open(raw) as src, open(dest, "wb") as dst:
+            shutil.copyfileobj(src, dst, _CHUNK)
+
+    def archive_path(self) -> Path | None:
+        return self._path
+
+    def close(self) -> None:
+        self._zip.close()
+
+
+class RarSource:
+    def __init__(self, path: Path) -> None:
+        self.name = path.name
+        self.kind = "rar"
+        self._path = path
+        self._rar = rarfile.RarFile(path)
+        self._raw_by_path: dict[str, str] = {}
+        for info in self._rar.infolist():
+            if info.isdir():
+                continue
+            cleaned = _clean_name(info.filename)
+            if cleaned:
+                self._raw_by_path.setdefault(cleaned, info.filename)
+
+    def entries(self) -> list[SourceEntry]:
+        out: list[SourceEntry] = []
+        for info in self._rar.infolist():
+            cleaned = _clean_name(info.filename)
+            if not cleaned:
+                continue
+            out.append(SourceEntry(cleaned, cleaned, info.file_size, info.isdir()))
+        return out
+
+    def extract_member(self, entry_path: str, dest: Path) -> None:
+        raw = self._raw_by_path[entry_path]
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        with self._rar.open(raw) as src, open(dest, "wb") as dst:
+            shutil.copyfileobj(src, dst, _CHUNK)
+
+    def archive_path(self) -> Path | None:
+        return self._path
+
+    def close(self) -> None:
+        self._rar.close()
+
+
+class SevenZipSource:
+    def __init__(self, path: Path) -> None:
+        self.name = path.name
+        self.kind = "7z"
+        self._path = path
+        self._members: list[SourceEntry] = []
+        self._raw_by_path: dict[str, str] = {}
+        with py7zr.SevenZipFile(path, "r") as archive:
+            for info in archive.list():
+                cleaned = _clean_name(info.filename)
+                if not cleaned:
+                    continue
+                size = int(getattr(info, "uncompressed", 0) or 0)
+                self._members.append(SourceEntry(cleaned, cleaned, size, info.is_directory))
+                if not info.is_directory:
+                    self._raw_by_path.setdefault(cleaned, info.filename)
+
+    def entries(self) -> list[SourceEntry]:
+        return list(self._members)
+
+    def extract_member(self, entry_path: str, dest: Path) -> None:
+        raw = self._raw_by_path[entry_path]
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        # py7zr has no cheap per-member stream, so extract into a scratch dir and copy out.
+        with tempfile.TemporaryDirectory() as scratch:
+            with py7zr.SevenZipFile(self._path, "r") as archive:
+                archive.extract(path=scratch, targets=[raw])
+            extracted = Path(scratch) / raw
+            shutil.copyfile(extracted, dest)
+
+    def archive_path(self) -> Path | None:
+        return self._path
+
+    def close(self) -> None:
+        return None
+
+
+class DirSource:
+    def __init__(self, path: Path) -> None:
+        self.name = path.name
+        self.kind = "dir"
+        self._root = path
+
+    def entries(self) -> list[SourceEntry]:
+        out: list[SourceEntry] = []
+        for dirpath, dirnames, filenames in os.walk(self._root):
+            rel_dir = Path(dirpath).relative_to(self._root)
+            for name in dirnames:
+                rel = (rel_dir / name).as_posix()
+                out.append(SourceEntry(rel, rel, 0, True))
+            for name in filenames:
+                rel = (rel_dir / name).as_posix()
+                try:
+                    size = (Path(dirpath) / name).stat().st_size
+                except OSError:
+                    size = 0
+                out.append(SourceEntry(rel, rel, size, False))
+        return out
+
+    def extract_member(self, entry_path: str, dest: Path) -> None:
+        src = self._root / Path(*PurePosixPath(entry_path).parts)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(src, dest)
+
+    def archive_path(self) -> Path | None:
+        return None
+
+    def close(self) -> None:
+        return None
+
+
+class SingleFileSource:
+    def __init__(self, path: Path) -> None:
+        self.name = path.name
+        self.kind = "file"
+        self._path = path
+
+    def entries(self) -> list[SourceEntry]:
+        try:
+            size = self._path.stat().st_size
+        except OSError:
+            size = 0
+        return [SourceEntry(self._path.name, self._path.name, size, False)]
+
+    def extract_member(self, entry_path: str, dest: Path) -> None:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(self._path, dest)
+
+    def archive_path(self) -> Path | None:
+        return self._path
+
+    def close(self) -> None:
+        return None
+
+
+def configure_rar_tool(path: str) -> None:
+    """Point rarfile at a specific unar/unrar/bsdtar binary.
+
+    An empty path leaves rarfile's default behavior, which searches PATH for the tool.
+    A value is useful when the tool is installed somewhere off PATH (common on locked-down
+    cabs launched from a frontend or service with a minimal environment).
+    """
+    if rarfile is None or not path:
+        return
+    name = Path(path).name.lower()
+    if "unrar" in name:
+        rarfile.UNRAR_TOOL = path
+    elif "unar" in name:
+        rarfile.UNAR_TOOL = path
+    elif "bsdtar" in name:
+        rarfile.BSDTAR_TOOL = path
+    else:
+        rarfile.UNRAR_TOOL = path   # assume an unrar-compatible binary
+
+
+def rar_tool_available() -> bool:
+    """True if rarfile can find a working extraction tool (unrar, unar, or bsdtar)."""
+    if rarfile is None:
+        return False
+    try:
+        rarfile.tool_setup(force=True)
+        return True
+    except Exception:
+        return False
+
+
+def rar_tool_hint() -> str:
+    """Platform-appropriate guidance for installing a RAR extraction tool.
+
+    Deliberately avoids naming a specific package manager — Linux distributions differ —
+    and points at the configurable path setting as the alternative to a PATH install.
+    """
+    if sys.platform.startswith("win"):
+        return ("RAR support needs UnRAR.exe, which ships with WinRAR or 7-Zip. Install one "
+                "of those, or set the RAR tool path in Configuration.")
+    if sys.platform == "darwin":
+        how = "install it (for example, brew install unar)"
+    else:
+        how = "install it from your distribution's package manager (usually the 'unar' or 'unrar' package)"
+    return (f"RAR support needs the 'unar' or 'unrar' tool — {how}, "
+            "or set the RAR tool path in Configuration.")
+
+
+def open_source(path: Path) -> AssetSource:
+    """Open a path as a uniform asset source (directory, archive, or single file)."""
+    path = Path(path)
+    if path.is_dir():
+        return DirSource(path)
+    ext = path.suffix.lower()
+    if ext in {".zip", ".vpxz"}:
+        return ZipSource(path)
+    if ext == ".rar":
+        if rarfile is None:
+            raise _MissingBackend("RAR support requires the 'rarfile' package")
+        return RarSource(path)
+    if ext == ".7z":
+        if py7zr is None:
+            raise _MissingBackend("7z support requires the 'py7zr' package")
+        return SevenZipSource(path)
+    return SingleFileSource(path)
+
+
+class _MissingBackend(RuntimeError):
+    pass
+
+
+# --- Normalization ---------------------------------------------------------
+
+def _is_junk(arcname: str) -> bool:
+    parts = [p.lower() for p in PurePosixPath(arcname).parts]
+    if any(p in _JUNK_COMPONENTS for p in parts):
+        return True
+    base = PurePosixPath(arcname).name
+    return base.startswith("._")
+
+
+def _normalize(entries: list[SourceEntry]) -> list[SourceEntry]:
+    # Drop OS junk only. A wrapper directory is intentionally left in place: folder
+    # kinds carry a `root` and import lays them out relative to it, so a redundant
+    # top folder never reaches the destination, while pack detection keeps its signal.
+    return [e for e in entries if e.arcname and not _is_junk(e.arcname)]
+
+
+# --- Detection helpers -----------------------------------------------------
+
+def _parent(arcname: str) -> str:
+    parent = PurePosixPath(arcname).parent
+    return "" if str(parent) == "." else str(parent)
+
+
+def _under(arcname: str, root: str) -> bool:
+    if root == "":
+        return True
+    return arcname == root or arcname.startswith(root + "/")
+
+
+def _suffix(arcname: str) -> str:
+    return PurePosixPath(arcname).suffix.lower()
+
+
+def _basename(arcname: str) -> str:
+    return PurePosixPath(arcname).name
+
+
+# --- Detection -------------------------------------------------------------
+
+def _analyze_entries(entries: list[SourceEntry]) -> tuple[list[DetectedAsset], list[str], bool]:
+    norm = _normalize(entries)
+    files = [e for e in norm if not e.is_dir]
+    claimed: set[str] = set()
+    assets: list[DetectedAsset] = []
+    notes: list[str] = []
+
+    def unclaimed() -> list[SourceEntry]:
+        return [e for e in files if e.path not in claimed]
+
+    def claim_subtree(root: str) -> list[SourceEntry]:
+        picked = [e for e in files if e.path not in claimed and _under(e.arcname, root)]
+        for e in picked:
+            claimed.add(e.path)
+        return picked
+
+    # 1. Table
+    has_table = False
+    vpx_dirs: set[str] = set()
+    for e in list(unclaimed()):
+        if _suffix(e.arcname) == ".vpx":
+            claimed.add(e.path)
+            has_table = True
+            vpx_dirs.add(_parent(e.arcname))
+            assets.append(DetectedAsset("table", "Table", (e,), size=e.size, detail=_basename(e.arcname)))
+
+    # 1b. Table metadata — bundle-scoped only: a .info beside a claimed .vpx. A lone
+    # .info stays unrecognized (wholesale metadata replacement is never inferred).
+    for e in list(unclaimed()):
+        if _suffix(e.arcname) == ".info" and _parent(e.arcname) in vpx_dirs:
+            claimed.add(e.path)
+            assets.append(DetectedAsset("table_info", "Metadata", (e,), size=e.size,
+                                        detail=_basename(e.arcname)))
+
+    # 2. Backglass
+    for e in list(unclaimed()):
+        if _suffix(e.arcname) == ".directb2s":
+            claimed.add(e.path)
+            assets.append(DetectedAsset("backglass", "Backglass", (e,), size=e.size, detail=_basename(e.arcname)))
+
+    # Subtree claimers run before loose-file claimers so files inside a pack are not grabbed loose.
+    # 3. AltSound
+    altsound_roots: list[str] = []
+    for e in unclaimed():
+        if _basename(e.arcname).lower() in _ALTSOUND_MARKERS:
+            altsound_roots.append(_parent(e.arcname))
+    for root in _dedupe_roots(altsound_roots):
+        picked = claim_subtree(root)
+        if picked:
+            assets.append(DetectedAsset(
+                "altsound", "AltSound", tuple(picked), root=root,
+                size=sum(p.size for p in picked), detail=f"{len(picked)} files"))
+
+    # 4. PUP pack
+    pup_roots = _find_pup_roots(unclaimed())
+    for root in pup_roots:
+        picked = claim_subtree(root)
+        if picked:
+            assets.append(DetectedAsset(
+                "pup_pack", "PUP Pack", tuple(picked), root=root,
+                size=sum(p.size for p in picked), detail=f"{len(picked)} files"))
+
+    # 5. Music
+    for root in _find_music_roots(unclaimed()):
+        picked = claim_subtree(root)
+        if picked:
+            assets.append(DetectedAsset(
+                "music", "Music", tuple(picked), root=root,
+                size=sum(p.size for p in picked), detail=f"{len(picked)} files"))
+
+    # 6. AltColor
+    for e in list(unclaimed()):
+        if _suffix(e.arcname) == ".crz":
+            claimed.add(e.path)
+            assets.append(DetectedAsset("altcolor_serum", "Serum Color", (e,), size=e.size, detail=_basename(e.arcname)))
+    vni_by_dir: dict[str, list[SourceEntry]] = {}
+    for e in unclaimed():
+        if _suffix(e.arcname) in {".vni", ".pal", ".pac"}:
+            vni_by_dir.setdefault(_parent(e.arcname), []).append(e)
+    for group in vni_by_dir.values():
+        for e in group:
+            claimed.add(e.path)
+        assets.append(DetectedAsset(
+            "altcolor_vni", "VNI/PAL Color", tuple(group),
+            size=sum(g.size for g in group), detail=", ".join(_basename(g.arcname) for g in group)))
+
+    # 7. ROM
+    remaining = unclaimed()
+    is_flat = not any(e.is_dir for e in norm) and all("/" not in e.arcname for e in remaining)
+    if remaining and is_flat and all(_is_rom_suffix(e.arcname) for e in remaining):
+        for e in remaining:
+            claimed.add(e.path)
+        assets.append(DetectedAsset(
+            "rom", "ROM", tuple(remaining), size=sum(e.size for e in remaining),
+            detail="whole archive"))
+    else:
+        for e in list(unclaimed()):
+            if _suffix(e.arcname) == ".zip":
+                claimed.add(e.path)
+                assets.append(DetectedAsset("rom", "ROM", (e,), size=e.size, detail=_basename(e.arcname)))
+
+    # 8. INI
+    for e in list(unclaimed()):
+        if _suffix(e.arcname) == ".ini":
+            claimed.add(e.path)
+            assets.append(DetectedAsset("ini", "Table INI", (e,), size=e.size, detail=_basename(e.arcname)))
+
+    # 9. Media
+    for e in list(unclaimed()):
+        media_key = match_media_key(_basename(e.arcname))
+        if media_key:
+            claimed.add(e.path)
+            assets.append(DetectedAsset(
+                "media", spec_for("media").label, (e,), media_key=media_key,
+                size=e.size, detail=f"{_basename(e.arcname)} → {media_key}"))
+
+    unrecognized = tuple(e.arcname for e in files if e.path not in claimed)
+    return assets, notes, has_table, unrecognized
+
+
+def _dedupe_roots(roots: list[str]) -> list[str]:
+    """Keep only outermost roots (drop any root nested under another)."""
+    unique = sorted(set(roots), key=lambda r: (len(PurePosixPath(r).parts), r))
+    kept: list[str] = []
+    for root in unique:
+        if any(_under(root, existing) and root != existing for existing in kept):
+            continue
+        kept.append(root)
+    return kept
+
+
+def _find_pup_roots(entries: list[SourceEntry]) -> list[str]:
+    marker_roots: list[str] = []
+    for e in entries:
+        base = _basename(e.arcname).lower()
+        if base in _PUP_MARKERS_EXACT or any(fnmatch.fnmatch(base, g) for g in _PUP_MARKER_GLOBS):
+            marker_roots.append(_parent(e.arcname))
+    if marker_roots:
+        return _dedupe_roots(marker_roots)
+    return _find_pup_roots_by_shape(entries)
+
+
+def _find_pup_roots_by_shape(entries: list[SourceEntry]) -> list[str]:
+    subdirs: dict[str, set[str]] = {}
+    videos: dict[str, int] = {}
+    for e in entries:
+        parts = PurePosixPath(e.arcname).parts
+        if len(parts) < 2:
+            continue
+        root = parts[0]
+        subdirs.setdefault(root, set()).add(parts[1])
+        if _suffix(e.arcname) in _VIDEO_SUFFIXES:
+            videos[root] = videos.get(root, 0) + 1
+    roots = [
+        root for root, dirs in subdirs.items()
+        if len(dirs) >= _PUP_FALLBACK_MIN_SUBDIRS and videos.get(root, 0) >= _PUP_FALLBACK_MIN_VIDEOS
+    ]
+    return _dedupe_roots(roots)
+
+
+def _find_music_roots(entries: list[SourceEntry]) -> list[str]:
+    by_dir: dict[str, list[SourceEntry]] = {}
+    for e in entries:
+        top = PurePosixPath(e.arcname).parts[0] if PurePosixPath(e.arcname).parts else ""
+        if top == "" or "/" not in e.arcname:
+            continue   # root-level files are ambiguous (e.g. table audio.mp3); leave to media
+        by_dir.setdefault(top, []).append(e)
+    roots: list[str] = []
+    for root, members in by_dir.items():
+        suffixes = {_suffix(m.arcname) for m in members}
+        has_audio = bool(suffixes & _AUDIO_SUFFIXES)
+        has_video = bool(suffixes & _VIDEO_SUFFIXES)
+        if has_audio and not has_video and suffixes <= _AUDIO_SUFFIXES:
+            roots.append(root)
+    return roots
+
+
+def _is_rom_suffix(arcname: str) -> bool:
+    suffix = _suffix(arcname)
+    if suffix in _ROM_SUFFIXES:
+        return True
+    ext = suffix.lstrip(".")
+    return 1 <= len(ext) <= 2 and ext[-1:].isdigit()
+
+
+_INFO_MAX_BYTES = 2 * 1024 * 1024
+
+
+def _read_bundle_info(source: AssetSource, asset: DetectedAsset) -> dict | None:
+    """Extract and parse a bundle's .info; None if oversized, unreadable, or not a JSON dict."""
+    import json
+
+    entry = asset.entries[0]
+    if entry.size > _INFO_MAX_BYTES:
+        return None
+    with tempfile.TemporaryDirectory() as scratch:
+        dest = Path(scratch) / "bundle.info"
+        try:
+            source.extract_member(entry.path, dest)
+            data = json.loads(dest.read_text(encoding="utf-8"))
+        except Exception:
+            logger.warning("Unreadable bundle .info: %s", entry.arcname)
+            return None
+    return data if isinstance(data, dict) else None
+
+
+# --- Public API ------------------------------------------------------------
+
+def analyze_path(path: Path) -> AnalysisResult:
+    """Analyze a file, archive, or directory and report the assets it contains."""
+    path = Path(path)
+    try:
+        source = open_source(path)
+    except _MissingBackend as exc:
+        return AnalysisResult(_source_kind(path), path.name, (), False, error=str(exc))
+    except Exception:
+        logger.exception("Failed to open source: %s", path)
+        return AnalysisResult(_source_kind(path), path.name, (), False, error="Could not read the dropped item")
+
+    # Surface a missing RAR tool up front, before the confirm dialog, rather than
+    # failing at extraction time after the user has committed to the import.
+    if source.kind == "rar" and not rar_tool_available():
+        source.close()
+        return AnalysisResult(source.kind, source.name, (), False, error=rar_tool_hint())
+
+    try:
+        try:
+            entries = source.entries()
+        except _rar_exec_errors() as exc:
+            logger.warning("RAR backend unavailable: %s", exc)
+            return AnalysisResult(source.kind, source.name, (), False,
+                                  error="RAR extraction requires the 'unar' or 'unrar' tool to be installed")
+        except Exception:
+            logger.exception("Failed to list source: %s", path)
+            return AnalysisResult(source.kind, source.name, (), False, error="Could not read the dropped item")
+
+        assets, notes, has_table, unrecognized = _analyze_entries(entries)
+
+        # A bundle .info is read up front (it is tiny) so its content can seed the
+        # import dialog and be validated before anything is written.
+        bundle_info = None
+        info_assets = [a for a in assets if a.kind == "table_info"]
+        if info_assets:
+            bundle_info = _read_bundle_info(source, info_assets[0])
+            if bundle_info is None:
+                assets = [a for a in assets if a.kind != "table_info"]
+                unrecognized = unrecognized + tuple(e.arcname for e in info_assets[0].entries)
+                notes = list(notes) + ["bundle .info is not valid metadata and was skipped"]
+    finally:
+        source.close()
+
+    if not assets:
+        return AnalysisResult(source.kind, source.name, (), False, tuple(notes),
+                              error="No recognized assets found", unrecognized=unrecognized)
+    return AnalysisResult(source.kind, source.name, tuple(assets), has_table, tuple(notes),
+                          unrecognized=unrecognized, bundle_info=bundle_info)
+
+
+def analyze_upload_session(session_dir: Path) -> tuple[AnalysisResult, Path]:
+    """Analyze a staged upload session and return the result plus the path to analyze/import from.
+
+    A session holding a single archive analyzes that archive; a single non-archive file
+    is analyzed on its own; anything else is treated as a dropped folder tree.
+    """
+    session_dir = Path(session_dir)
+    top_files = [p for p in session_dir.iterdir() if p.is_file()]
+    top_dirs = [p for p in session_dir.iterdir() if p.is_dir()]
+    if len(top_files) == 1 and not top_dirs:
+        only = top_files[0]
+        if only.suffix.lower() in ARCHIVE_EXTENSIONS:
+            return analyze_path(only), only
+        return analyze_path(only), only
+    return analyze_path(session_dir), session_dir
+
+
+def _source_kind(path: Path) -> str:
+    if path.is_dir():
+        return "dir"
+    ext = path.suffix.lower()
+    if ext in {".zip", ".vpxz"}:
+        return "zip"
+    if ext == ".rar":
+        return "rar"
+    if ext == ".7z":
+        return "7z"
+    return "file"
+
+
+def _rar_exec_errors() -> tuple[type[BaseException], ...]:
+    if rarfile is None:
+        return (RuntimeError,)
+    return (rarfile.RarCannotExec, rarfile.BadRarFile)

--- a/managerui/services/asset_import_service.py
+++ b/managerui/services/asset_import_service.py
@@ -1,0 +1,511 @@
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import tempfile
+import zipfile
+from dataclasses import dataclass, replace
+from pathlib import Path, PurePosixPath
+from typing import Callable
+
+from common.media_paths import media_filename_map
+from common.table_repository import refresh_table
+from managerui.paths import get_tables_path
+from managerui.services.asset_analyzer_service import (
+    AnalysisResult,
+    DetectedAsset,
+    SourceEntry,
+    open_source,
+)
+from managerui.services.asset_registry import ARCHIVE_EXTENSIONS, spec_for
+from managerui.services.media_service import IMAGE_EXTENSIONS, replace_media_file
+from managerui.services.table_service import (
+    _find_directb2s_file,
+    _find_ini_file,
+    _find_vpx_file,
+    _safe_upload_name,
+    ensure_dir,
+)
+
+
+logger = logging.getLogger("vpinfe.manager.asset_import")
+
+_MEDIA_FILENAMES = media_filename_map("table")
+
+
+@dataclass(frozen=True)
+class PlannedItem:
+    asset: DetectedAsset
+    destination: str        # absolute path (file target, or base dir for tree kinds)
+    action: str             # replace_vpx | replace_b2s | copy | zip_rom | extract_tree | replace_media
+    default_enabled: bool = True
+
+
+@dataclass(frozen=True)
+class BlockedItem:
+    asset: DetectedAsset
+    reason: str
+
+
+@dataclass(frozen=True)
+class ImportPlan:
+    table_path: str          # target table dir (existing, or the resolved new-table dir)
+    new_table_dir_name: str  # non-empty only for new-table bundle imports
+    rom_name: str
+    items: tuple[PlannedItem, ...]
+    blocked: tuple[BlockedItem, ...]
+
+
+def _basename(arcname: str) -> str:
+    return PurePosixPath(arcname).name
+
+
+def _is_rar_exec_error(exc: BaseException) -> bool:
+    try:
+        import rarfile
+    except ImportError:  # pragma: no cover - optional dependency
+        return False
+    return isinstance(exc, rarfile.RarCannotExec)
+
+
+def _safe_dest(base_dir: Path, relative: str) -> Path:
+    """Resolve a relative path under base_dir, rejecting traversal or absolute paths."""
+    rel = PurePosixPath(relative)
+    drive_letter = len(relative) >= 2 and relative[1] == ":"
+    if rel.is_absolute() or ".." in rel.parts or drive_letter:
+        raise ValueError(f"Unsafe path: {relative}")
+    dest = (base_dir / Path(*rel.parts)).resolve()
+    try:
+        dest.relative_to(base_dir.resolve())
+    except ValueError as exc:
+        raise ValueError(f"Unsafe path: {relative}") from exc
+    return dest
+
+
+def _rel_under_root(arcname: str, root: str) -> str:
+    if not root:
+        return arcname
+    if arcname == root:
+        return _basename(arcname)
+    if arcname.startswith(root + "/"):
+        return arcname[len(root) + 1:]
+    return _basename(arcname)
+
+
+def _rom_dest_name(asset: DetectedAsset, source_name: str) -> tuple[str, str]:
+    """Return (filename, action) for a ROM asset destination under pinmame/roms."""
+    if len(asset.entries) == 1 and PurePosixPath(asset.entries[0].arcname).suffix.lower() == ".zip":
+        return _safe_upload_name(_basename(asset.entries[0].arcname)), "copy"
+    stem = Path(source_name).stem or "rom"
+    return f"{_safe_upload_name(stem)}.zip", "zip_rom"
+
+
+def _plan_asset(asset: DetectedAsset, base: Path, vpx_stem: str, rom_name: str,
+                source_name: str, table_kind_action: str) -> tuple[PlannedItem | None, BlockedItem | None]:
+    kind = asset.kind
+    spec = spec_for(kind)
+    if spec.requires_rom and not rom_name:
+        return None, BlockedItem(asset, "Table has no ROM name; import a ROM first")
+
+    if kind == "table":
+        dest = base / _safe_upload_name(_basename(asset.entries[0].arcname))
+        return PlannedItem(asset, str(dest), table_kind_action), None
+    if kind == "table_info":
+        # Always written as <folder>.info — the parser matches it by folder name.
+        return PlannedItem(asset, str(base / f"{base.name}.info"), "write_info"), None
+    if kind == "backglass":
+        stem = vpx_stem or Path(_basename(asset.entries[0].arcname)).stem
+        return PlannedItem(asset, str(base / f"{stem}.directb2s"), "replace_b2s"), None
+    if kind == "ini":
+        stem = vpx_stem or Path(_basename(asset.entries[0].arcname)).stem
+        return PlannedItem(asset, str(base / f"{stem}.ini"), "copy"), None
+    if kind == "rom":
+        name, action = _rom_dest_name(asset, source_name)
+        return PlannedItem(asset, str(base / "pinmame" / "roms" / name), action), None
+    if kind == "altcolor_serum":
+        dest = base / "serum" / rom_name / _safe_upload_name(_basename(asset.entries[0].arcname))
+        return PlannedItem(asset, str(dest), "copy"), None
+    if kind == "altcolor_vni":
+        dest = base / "vni" / rom_name / _safe_upload_name(_basename(asset.entries[0].arcname))
+        return PlannedItem(asset, str(dest), "copy"), None
+    if kind == "altsound":
+        return PlannedItem(asset, str(base / "pinmame" / "altsound" / rom_name), "extract_tree"), None
+    if kind == "pup_pack":
+        return PlannedItem(asset, str(base / "pupvideos"), "extract_tree"), None
+    if kind == "music":
+        return PlannedItem(asset, str(base / "music"), "extract_tree"), None
+    if kind == "media":
+        filename = _MEDIA_FILENAMES.get(asset.media_key, asset.media_key)
+        return PlannedItem(asset, str(base / "medias" / filename), "replace_media"), None
+    return None, BlockedItem(asset, f"Unsupported asset type: {kind}")
+
+
+def build_import_plan(analysis: AnalysisResult, *, table_path: str = "", table_row: dict | None = None,
+                      rom_name: str = "", allow_new_table: bool = False,
+                      tables_path: str | None = None) -> ImportPlan:
+    """Route detected assets to destinations for an existing table or a new table bundle."""
+    items: list[PlannedItem] = []
+    blocked: list[BlockedItem] = []
+    new_bundle = analysis.has_table and allow_new_table
+
+    if new_bundle:
+        table_asset = next(a for a in analysis.assets if a.kind == "table")
+        vpx_stem = Path(_basename(table_asset.entries[0].arcname)).stem
+        new_dir_name = _safe_upload_name(vpx_stem)
+        base = Path(tables_path or get_tables_path()).expanduser() / new_dir_name
+        for asset in analysis.assets:
+            item, block = _plan_asset(asset, base, vpx_stem, rom_name, analysis.source_name,
+                                      table_kind_action="copy")
+            (items if item else blocked).append(item or block)
+        return ImportPlan(str(base), new_dir_name, "", tuple(items), tuple(blocked))
+
+    if table_path:
+        base = Path(table_path).expanduser()
+        try:
+            vpx_stem = _find_vpx_file(base).stem
+        except (FileNotFoundError, OSError):
+            vpx_stem = ""
+        # A table dropped onto an existing table replaces its .vpx (the "update table" case).
+        # New-table creation is handled by the new_bundle branch above.
+        for asset in analysis.assets:
+            item, block = _plan_asset(asset, base, vpx_stem, rom_name, analysis.source_name,
+                                      table_kind_action="replace_vpx")
+            (items if item else blocked).append(item or block)
+        return ImportPlan(str(base), "", rom_name, tuple(items), tuple(blocked))
+
+    for asset in analysis.assets:
+        if spec_for(asset.kind).requires_table:
+            blocked.append(BlockedItem(asset, "Select a table row, or drop onto a table's detail dialog"))
+        else:
+            blocked.append(BlockedItem(asset, "Drop onto the Tables page to import as a new table"))
+    return ImportPlan("", "", rom_name, (), tuple(blocked))
+
+
+def build_media_slot_plan(source_path: Path, *, table_path: str, media_key: str) -> ImportPlan:
+    """Plan a targeted media-slot import from a single dropped file.
+
+    The slot dictates the media key (no filename inference); the file only has to
+    belong to the slot's family (image slots take images, video slots .mp4, audio .mp3).
+    Unsuitable drops come back as a blocked item with the reason.
+    """
+    canonical = _MEDIA_FILENAMES.get(media_key)
+    if canonical is None:
+        raise ValueError(f"Unknown media slot: {media_key}")
+    src = Path(source_path)
+    try:
+        size = src.stat().st_size
+    except OSError:
+        size = 0
+    entry = SourceEntry(src.name, src.name, size, False)
+    asset = DetectedAsset("media", "Media", (entry,), media_key=media_key,
+                          size=size, detail=f"{src.name} → {media_key}")
+
+    if src.is_dir() or src.suffix.lower() in ARCHIVE_EXTENSIONS:
+        blocked = BlockedItem(asset, "Drop a single media file on a slot")
+        return ImportPlan(table_path, "", "", (), (blocked,))
+
+    slot_suffix = Path(canonical).suffix.lower()
+    suffix = src.suffix.lower()
+    if slot_suffix in {".mp4", ".mp3"}:
+        suitable = suffix == slot_suffix
+        expected = slot_suffix
+    else:
+        suitable = suffix in IMAGE_EXTENSIONS
+        expected = "an image file"
+    if not suitable:
+        blocked = BlockedItem(asset, f"This slot expects {expected}, not {suffix or 'a file without extension'}")
+        return ImportPlan(table_path, "", "", (), (blocked,))
+
+    destination = str(Path(table_path) / "medias" / canonical)
+    item = PlannedItem(asset, destination, "replace_media")
+    return ImportPlan(table_path, "", "", (item,), ())
+
+
+def sanitize_dir_name(name: str) -> str:
+    """Strip filesystem-reserved characters from a proposed table folder name."""
+    return "".join(c for c in (name or "") if c not in '<>:"/\\|?*').strip()
+
+
+def vps_folder_name(vps_entry: dict) -> str:
+    """Derive the canonical table folder name from a VPS entry (same shape the
+    Import Table dialog builds: "Name (Manufacturer Year)")."""
+    name = vps_entry.get("name", "")
+    mfg = vps_entry.get("manufacturer") or vps_entry.get("mfg") or ""
+    year = vps_entry.get("year") or ""
+    if mfg and year:
+        folder = f"{name} ({mfg} {year})"
+    elif mfg:
+        folder = f"{name} ({mfg})"
+    elif year:
+        folder = f"{name} ({year})"
+    else:
+        folder = name
+    return sanitize_dir_name(folder)
+
+
+def find_vps_entry(vps_id: str) -> dict | None:
+    """Look up a VPS entry by its id."""
+    from managerui.services.table_service import load_vpsdb
+
+    wanted = (vps_id or "").strip()
+    if not wanted:
+        return None
+    for entry in load_vpsdb():
+        if entry.get("id") == wanted:
+            return entry
+    return None
+
+
+def select_plan_items(plan: ImportPlan, indices: list[int] | None = None,
+                      new_table_dir_name: str | None = None) -> ImportPlan:
+    """Narrow a plan to the chosen item indices and optionally rename a new-table target.
+
+    indices=None keeps every item. For new-table bundles, passing a new name rebases all
+    item destinations under the renamed folder. Shared by the confirm dialog and the HTTP
+    import endpoint so both honor selection and rename identically.
+    """
+    if indices is None:
+        chosen = plan.items
+    else:
+        wanted = set(indices)
+        chosen = tuple(item for index, item in enumerate(plan.items) if index in wanted)
+
+    if not plan.new_table_dir_name:
+        return replace(plan, items=chosen)
+
+    new_name = sanitize_dir_name(new_table_dir_name) if new_table_dir_name is not None else plan.new_table_dir_name
+    if not new_name:
+        raise ValueError("Table folder name required")
+    if new_name == plan.new_table_dir_name:
+        return replace(plan, items=chosen)
+
+    old_base = plan.table_path
+    new_base = str(Path(old_base).parent / new_name)
+    rebased = tuple(replace(item, destination=item.destination.replace(old_base, new_base, 1)) for item in chosen)
+    return replace(plan, table_path=new_base, new_table_dir_name=new_name, items=rebased)
+
+
+_MANAGED_INFO_SECTIONS = {"Info", "User", "VPinFE", "VPXFile", "Medias"}
+_MACHINE_LOCAL_INFO_KEYS = {"altlauncher", "pluginprofile"}
+
+
+def _is_empty_value(value) -> bool:
+    return value in (None, "", 0, [], {})
+
+
+def _resolves_locally(key: str, value) -> bool:
+    """Machine-specific override values must exist on this machine to be adopted."""
+    text = str(value or "")
+    if not text:
+        return False
+    if key == "altlauncher":
+        return Path(text).expanduser().exists()
+    if key == "pluginprofile":
+        from managerui.paths import PLUGIN_PROFILES_DIR
+
+        try:
+            return any(p.stem == text or p.name == text for p in Path(PLUGIN_PROFILES_DIR).iterdir())
+        except OSError:
+            return False
+    return True
+
+
+def merge_info(incoming: dict, existing: dict) -> dict:
+    """Merge an imported .info into an existing one: fill gaps, never replace.
+
+    Info is adopted wholesale only when the existing table has no VPS association.
+    User and VPinFE fill empty fields (machine-specific overrides only if they resolve
+    locally). VPXFile and Medias always keep the local version — the first describes
+    whichever vpx is now on disk and is regenerated by a rebuild; the second describes
+    local media state. Unknown sections are added when absent, never replaced.
+    """
+    merged = dict(existing)
+
+    for section, value in incoming.items():
+        if section not in merged and section not in _MANAGED_INFO_SECTIONS:
+            merged[section] = value
+
+    if not (existing.get("Info") or {}).get("VPSId") and incoming.get("Info"):
+        merged["Info"] = incoming["Info"]
+
+    local_user = dict(existing.get("User") or {})
+    for key, value in (incoming.get("User") or {}).items():
+        if _is_empty_value(local_user.get(key)) and not _is_empty_value(value):
+            local_user[key] = value
+    if local_user:
+        merged["User"] = local_user
+
+    local_vpinfe = dict(existing.get("VPinFE") or {})
+    for key, value in (incoming.get("VPinFE") or {}).items():
+        if not _is_empty_value(local_vpinfe.get(key)) or _is_empty_value(value):
+            continue
+        if key in _MACHINE_LOCAL_INFO_KEYS and not _resolves_locally(key, value):
+            continue
+        local_vpinfe[key] = value
+    if local_vpinfe:
+        merged["VPinFE"] = local_vpinfe
+
+    return merged
+
+
+def _import_table_info(source, asset: DetectedAsset, base: Path) -> None:
+    import json
+
+    entry = asset.entries[0]
+    with tempfile.TemporaryDirectory() as scratch:
+        staged = Path(scratch) / "bundle.info"
+        source.extract_member(entry.path, staged)
+        incoming = json.loads(staged.read_text(encoding="utf-8"))
+    if not isinstance(incoming, dict):
+        raise ValueError("Bundle .info is not valid metadata")
+
+    dest = base / f"{base.name}.info"
+    if dest.exists():
+        try:
+            existing = json.loads(dest.read_text(encoding="utf-8"))
+        except Exception:
+            logger.warning("Existing .info is unreadable; treating as empty: %s", dest)
+            existing = {}
+        if not isinstance(existing, dict):
+            existing = {}
+        shutil.copy2(dest, dest.with_name(dest.name + ".bak"))
+        payload = merge_info(incoming, existing)
+    else:
+        payload = incoming
+
+    tmp = dest.with_name(f".{dest.name}.uploading")
+    tmp.write_text(json.dumps(payload, indent=4), encoding="utf-8")
+    os.replace(tmp, dest)
+
+
+# --- Execution -------------------------------------------------------------
+
+def _extract_replace(source, entry: SourceEntry, dest: Path) -> None:
+    ensure_dir(dest.parent)
+    tmp = dest.with_name(f".{dest.name}.uploading")
+    source.extract_member(entry.path, tmp)
+    os.replace(tmp, dest)
+
+
+def _replace_vpx_from_file(source, asset: DetectedAsset, base: Path) -> None:
+    entry = asset.entries[0]
+    safe = _safe_upload_name(_basename(entry.arcname))
+    if not safe.lower().endswith(".vpx"):
+        raise ValueError("Only .vpx files can update the table file")
+    new_vpx = base / safe
+    try:
+        old_vpx = _find_vpx_file(base)
+    except FileNotFoundError:
+        old_vpx = None
+    old_b2s = _find_directb2s_file(base, old_vpx.stem) if old_vpx else None
+    old_ini = _find_ini_file(base, old_vpx.stem) if old_vpx else None
+
+    tmp = new_vpx.with_name(f".{new_vpx.name}.uploading")
+    source.extract_member(entry.path, tmp)
+    if old_vpx and old_vpx.resolve() != new_vpx.resolve():
+        old_vpx.unlink()
+    os.replace(tmp, new_vpx)
+
+    if old_b2s and old_b2s.exists():
+        new_b2s = base / f"{new_vpx.stem}.directb2s"
+        if old_b2s.resolve() != new_b2s.resolve():
+            if new_b2s.exists():
+                new_b2s.unlink()
+            os.replace(old_b2s, new_b2s)
+    if old_ini and old_ini.exists():
+        new_ini = base / f"{new_vpx.stem}.ini"
+        if old_ini.resolve() != new_ini.resolve():
+            if new_ini.exists():
+                new_ini.unlink()
+            os.replace(old_ini, new_ini)
+    refresh_table(str(base))
+
+
+def _build_rom_zip(source, asset: DetectedAsset, dest: Path) -> None:
+    ensure_dir(dest.parent)
+    tmp = dest.with_name(f".{dest.name}.uploading")
+    with zipfile.ZipFile(tmp, "w", zipfile.ZIP_DEFLATED) as archive:
+        for entry in asset.entries:
+            if entry.is_dir:
+                continue
+            with tempfile.NamedTemporaryFile(delete=False) as handle:
+                scratch = Path(handle.name)
+            try:
+                source.extract_member(entry.path, scratch)
+                archive.write(scratch, arcname=_basename(entry.arcname))
+            finally:
+                scratch.unlink(missing_ok=True)
+    os.replace(tmp, dest)
+
+
+def _extract_tree(source, asset: DetectedAsset, base_dir: Path) -> None:
+    for entry in asset.entries:
+        if entry.is_dir:
+            continue
+        rel = _rel_under_root(entry.arcname, asset.root)
+        dest = _safe_dest(base_dir, rel)
+        source.extract_member(entry.path, dest)
+
+
+def _import_media(source, asset: DetectedAsset, table_path: Path) -> None:
+    entry = asset.entries[0]
+    suffix = PurePosixPath(entry.arcname).suffix
+    with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as handle:
+        scratch = Path(handle.name)
+    try:
+        source.extract_member(entry.path, scratch)
+        replace_media_file(str(table_path), table_path.name, asset.media_key, str(scratch))
+    finally:
+        scratch.unlink(missing_ok=True)
+
+
+def execute_import_plan(plan: ImportPlan, source_path: Path,
+                        *, progress_cb: Callable[[str], None] | None = None) -> dict:
+    """Execute an import plan, streaming each asset from source_path to its destination."""
+    base = Path(plan.table_path)
+    if plan.new_table_dir_name:
+        if base.exists():
+            raise ValueError(f"Table folder already exists: {base.name}")
+        base.mkdir(parents=True)
+
+    source = open_source(Path(source_path))
+    imported: list[str] = []
+    media_keys: list[str] = []
+    try:
+        for item in plan.items:
+            if progress_cb:
+                progress_cb(spec_for(item.asset.kind).label)
+            dest = Path(item.destination)
+            if item.action == "replace_vpx":
+                _replace_vpx_from_file(source, item.asset, base)
+            elif item.action == "replace_b2s":
+                _extract_replace(source, item.asset.entries[0], dest)
+            elif item.action == "copy":
+                _extract_replace(source, item.asset.entries[0], dest)
+            elif item.action == "zip_rom":
+                _build_rom_zip(source, item.asset, dest)
+            elif item.action == "extract_tree":
+                _extract_tree(source, item.asset, dest)
+            elif item.action == "write_info":
+                _import_table_info(source, item.asset, base)
+            elif item.action == "replace_media":
+                _import_media(source, item.asset, base)
+                media_keys.append(item.asset.media_key)
+            else:
+                raise ValueError(f"Unknown import action: {item.action}")
+            imported.append(item.asset.kind)
+    except Exception as exc:
+        if _is_rar_exec_error(exc):
+            raise ValueError("RAR extraction requires the 'unar' or 'unrar' tool to be installed") from exc
+        raise
+    finally:
+        source.close()
+
+    return {
+        "imported": imported,
+        "skipped": [b.asset.kind for b in plan.blocked],
+        "table_path": str(base),
+        "new_table": bool(plan.new_table_dir_name),
+        "media_keys": media_keys,
+    }

--- a/managerui/services/asset_registry.py
+++ b/managerui/services/asset_registry.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+from common.media_paths import media_filename_map
+from managerui.services.media_service import IMAGE_EXTENSIONS
+
+
+logger = logging.getLogger("vpinfe.manager.asset_registry")
+
+# Archive containers are opened and inspected, never classified as a bare file.
+ARCHIVE_EXTENSIONS = frozenset({".zip", ".vpxz", ".rar", ".7z"})
+
+VIDEO_EXTENSIONS = frozenset({".mp4"})
+AUDIO_EXTENSIONS = frozenset({".mp3"})
+MEDIA_EXTENSIONS = frozenset(IMAGE_EXTENSIONS) | VIDEO_EXTENSIONS | AUDIO_EXTENSIONS
+
+
+@dataclass(frozen=True)
+class AssetSpec:
+    key: str
+    label: str
+    icon: str
+    extensions: tuple[str, ...]     # lowercase; () for marker/folder-detected kinds
+    requires_table: bool
+    requires_rom: bool
+    allow_multiple: bool
+
+
+ASSET_SPECS = (
+    AssetSpec("table", "Table", "casino", (".vpx",), False, False, False),
+    AssetSpec("table_info", "Metadata", "description", (), True, False, False),
+    AssetSpec("backglass", "Backglass", "wallpaper", (".directb2s",), True, False, False),
+    AssetSpec("ini", "Table INI", "tune", (".ini",), True, False, False),
+    AssetSpec("rom", "ROM", "memory", (), True, False, True),
+    AssetSpec("altcolor_serum", "Serum Color", "palette", (".crz",), True, True, True),
+    AssetSpec("altcolor_vni", "VNI/PAL Color", "palette", (".vni", ".pal", ".pac"), True, True, True),
+    AssetSpec("altsound", "AltSound", "volume_up", (), True, True, False),
+    AssetSpec("pup_pack", "PUP Pack", "video_library", (), True, False, False),
+    AssetSpec("music", "Music", "music_note", (), True, False, False),
+    AssetSpec("media", "Media", "image", tuple(sorted(MEDIA_EXTENSIONS)), True, False, True),
+)
+
+_SPECS_BY_KEY = {spec.key: spec for spec in ASSET_SPECS}
+
+# Canonical media filenames (bg.png, dmd.mp4, audio.mp3, ...) -> media key.
+_MEDIA_FILENAME_TO_KEY = {filename: key for key, filename in media_filename_map("table").items()}
+
+# Keyword-in-stem fallbacks when a media file is not named canonically.
+# Ordered; realdmd is handled ahead of this table so "dmd" never claims a realdmd file.
+_MEDIA_KEYWORDS: tuple[tuple[tuple[str, ...], str, str | None], ...] = (
+    (("wheel", "logo"), "wheel", None),
+    (("backglass", "b2s"), "bg", "bg_video"),
+    (("dmd",), "dmd", "dmd_video"),
+    (("playfield", "table", "pf"), "table", "table_video"),
+    (("cabinet", "cab"), "cab", None),
+    (("flyer",), "flyer", None),
+    (("fss",), "fss", None),
+)
+
+
+def spec_for(key: str) -> AssetSpec:
+    """Return the AssetSpec for a kind key, raising KeyError if unknown."""
+    return _SPECS_BY_KEY[key]
+
+
+def classify_bare_extension(filename: str) -> AssetSpec | None:
+    """Classify a single non-archive file by its extension, or None if unrecognized."""
+    ext = Path(filename).suffix.lower()
+    if not ext or ext in ARCHIVE_EXTENSIONS:
+        return None
+    for spec in ASSET_SPECS:
+        if ext in spec.extensions:
+            return spec
+    return None
+
+
+def match_media_key(filename: str) -> str | None:
+    """Resolve a media file to its canonical media slot key (bg, wheel, ...), or None.
+
+    Exact canonical filenames win; otherwise a keyword in the stem plus the extension
+    family (image vs video vs audio) decides the slot.
+    """
+    ext = Path(filename).suffix.lower()
+    if ext not in MEDIA_EXTENSIONS:
+        return None
+
+    name = Path(filename).name.lower()
+    if name in _MEDIA_FILENAME_TO_KEY:
+        return _MEDIA_FILENAME_TO_KEY[name]
+
+    stem = Path(filename).stem.lower()
+
+    if ext in AUDIO_EXTENSIONS:
+        # audio is the only audio slot, so any recognized audio file lands there.
+        return "audio"
+
+    if "realdmd" in stem or "real dmd" in stem or "real-dmd" in stem:
+        if ext in IMAGE_EXTENSIONS:
+            return "realdmd_color" if "color" in stem else "realdmd"
+        return None
+
+    for keywords, image_key, video_key in _MEDIA_KEYWORDS:
+        if any(kw in stem for kw in keywords):
+            if ext in VIDEO_EXTENSIONS:
+                return video_key
+            if ext in IMAGE_EXTENSIONS:
+                return image_key
+    return None

--- a/managerui/services/upload_session_service.py
+++ b/managerui/services/upload_session_service.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import logging
+import shutil
+import tempfile
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+
+logger = logging.getLogger("vpinfe.manager.upload_session")
+
+MAX_TOTAL_BYTES = 20 * 1024 ** 3      # 20 GiB per session (PUP packs are large)
+SESSION_TTL_SECONDS = 3600
+_CHUNK = 1024 * 1024
+
+
+class UnknownSession(ValueError):
+    pass
+
+
+class UnsafePath(ValueError):
+    pass
+
+
+class UploadTooLarge(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class UploadSession:
+    upload_id: str
+    directory: str
+    created: float
+
+
+_sessions: dict[str, dict] = {}     # upload_id -> {"dir": str, "created": float, "bytes": int}
+_lock = threading.Lock()
+
+
+def _safe_join(base: Path, relative: str) -> Path:
+    rel = PurePosixPath(relative.replace("\\", "/"))
+    drive_letter = len(relative) >= 2 and relative[1] == ":"
+    if not relative or rel.is_absolute() or ".." in rel.parts or drive_letter:
+        raise UnsafePath(f"Unsafe upload path: {relative}")
+    dest = (base / Path(*rel.parts)).resolve()
+    try:
+        dest.relative_to(base.resolve())
+    except ValueError as exc:
+        raise UnsafePath(f"Unsafe upload path: {relative}") from exc
+    return dest
+
+
+def _sweep() -> None:
+    now = time.time()
+    with _lock:
+        stale = [uid for uid, rec in _sessions.items() if now - rec["created"] > SESSION_TTL_SECONDS]
+        records = [_sessions.pop(uid) for uid in stale]
+    for rec in records:
+        shutil.rmtree(rec["dir"], ignore_errors=True)
+
+
+def begin_session() -> UploadSession:
+    """Create a fresh upload session backed by a temp directory (sweeping expired ones first)."""
+    _sweep()
+    upload_id = uuid.uuid4().hex
+    directory = tempfile.mkdtemp(prefix="vpinfe_upload_")
+    created = time.time()
+    with _lock:
+        _sessions[upload_id] = {"dir": directory, "created": created, "bytes": 0}
+    return UploadSession(upload_id, directory, created)
+
+
+def _record(upload_id: str) -> dict:
+    with _lock:
+        rec = _sessions.get(upload_id)
+    if rec is None:
+        raise UnknownSession("Unknown upload session")
+    return rec
+
+
+def store_file(upload_id: str, relpath: str, stream) -> int:
+    """Stream a single uploaded file into the session directory at its relative path."""
+    rec = _record(upload_id)
+    dest = _safe_join(Path(rec["dir"]), relpath)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    written = 0
+    with open(dest, "wb") as out:
+        while True:
+            chunk = stream.read(_CHUNK)
+            if not chunk:
+                break
+            written += len(chunk)
+            with _lock:
+                rec["bytes"] += len(chunk)
+                total = rec["bytes"]
+            if total > MAX_TOTAL_BYTES:
+                raise UploadTooLarge("Upload exceeds the maximum allowed size")
+            out.write(chunk)
+    return written
+
+
+def get_session_dir(upload_id: str) -> Path:
+    return Path(_record(upload_id)["dir"])
+
+
+def finish_session(upload_id: str) -> dict:
+    directory = get_session_dir(upload_id)
+    files = [p for p in directory.rglob("*") if p.is_file()]
+    return {"file_count": len(files), "total_bytes": sum(p.stat().st_size for p in files)}
+
+
+def cleanup_session(upload_id: str) -> None:
+    with _lock:
+        rec = _sessions.pop(upload_id, None)
+    if rec is not None:
+        shutil.rmtree(rec["dir"], ignore_errors=True)

--- a/managerui/static/dnd_upload.css
+++ b/managerui/static/dnd_upload.css
@@ -1,0 +1,43 @@
+.dnd-drop-zone {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 1.1rem;
+  border: 2px dashed var(--line);
+  border-radius: var(--radius);
+  color: var(--ink-muted);
+  background: var(--bg);
+  cursor: copy;
+  text-align: center;
+  transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease;
+}
+
+.dnd-drop-zone:hover {
+  border-color: var(--neon-purple);
+  color: var(--ink);
+}
+
+.dnd-drop-zone--active {
+  border-color: var(--neon-purple);
+  color: var(--ink);
+  background: var(--surface);
+  box-shadow: 0 0 0 1px var(--neon-purple) inset;
+}
+
+.dnd-drop-zone__icon {
+  font-size: 1.4rem;
+  color: var(--neon-purple);
+}
+
+tr.dnd-row-active td {
+  background: var(--surface) !important;
+  box-shadow: inset 0 0 0 1px var(--neon-purple);
+}
+
+td.dnd-cell-active {
+  background: var(--surface) !important;
+  box-shadow: inset 0 0 0 2px var(--neon-purple);
+  border-radius: 4px;
+}

--- a/managerui/static/dnd_upload.js
+++ b/managerui/static/dnd_upload.js
@@ -1,0 +1,259 @@
+// Reusable drag/drop target for the manager UI. Walks dropped files and folders,
+// streams them to /api/asset-upload/* with their relative paths, and reports status
+// back to Python via the NiceGUI global-event bridge (emitEvent -> ui.on).
+(function () {
+  if (window.vpinfeDnd) return;
+
+  function emit(payload) {
+    if (typeof emitEvent === 'function') {
+      emitEvent('vpinfe_dnd', payload);
+    }
+  }
+
+  function readEntries(reader) {
+    return new Promise((resolve, reject) => reader.readEntries(resolve, reject));
+  }
+
+  function fileFromEntry(entry) {
+    return new Promise((resolve, reject) => entry.file(resolve, reject));
+  }
+
+  async function walkEntry(entry, collected) {
+    if (entry.isFile) {
+      const file = await fileFromEntry(entry);
+      collected.push({ relpath: entry.fullPath.replace(/^\/+/, ''), file: file });
+    } else if (entry.isDirectory) {
+      const reader = entry.createReader();
+      // readEntries returns at most ~100 entries per call, so loop until empty.
+      while (true) {
+        const batch = await readEntries(reader);
+        if (!batch.length) break;
+        for (const child of batch) await walkEntry(child, collected);
+      }
+    }
+  }
+
+  async function collectFiles(dataTransfer) {
+    const entries = [];
+    const items = dataTransfer.items ? Array.from(dataTransfer.items) : [];
+    for (const item of items) {
+      const entry = item.webkitGetAsEntry ? item.webkitGetAsEntry() : null;
+      if (entry) entries.push(entry);
+    }
+    const collected = [];
+    if (entries.length) {
+      for (const entry of entries) await walkEntry(entry, collected);
+    } else {
+      for (const file of Array.from(dataTransfer.files || [])) {
+        collected.push({ relpath: file.name, file: file });
+      }
+    }
+    return collected;
+  }
+
+  async function uploadAll(token, files) {
+    const begin = await fetch('/api/asset-upload/begin', { method: 'POST' });
+    const uploadId = (await begin.json()).upload_id;
+    let done = 0;
+    for (const item of files) {
+      const form = new FormData();
+      form.append('upload_id', uploadId);
+      form.append('relpath', item.relpath);
+      form.append('file', item.file, item.file.name);
+      const resp = await fetch('/api/asset-upload/file', { method: 'POST', body: form });
+      if (!resp.ok) {
+        let message = 'Upload failed';
+        try { message = (await resp.json()).error || message; } catch (e) { /* ignore */ }
+        await fetch('/api/asset-upload/abort', {
+          method: 'POST',
+          body: new URLSearchParams({ upload_id: uploadId }),
+        });
+        throw new Error(message);
+      }
+      done += 1;
+      emit({ token: token, status: 'progress', done: done, total: files.length, name: item.relpath });
+    }
+    const finish = await fetch('/api/asset-upload/finish', {
+      method: 'POST',
+      body: new URLSearchParams({ upload_id: uploadId }),
+    });
+    return { uploadId: uploadId, info: await finish.json() };
+  }
+
+  function rootName(files) {
+    if (files.length === 1) return files[0].relpath;
+    const first = files[0].relpath;
+    const slash = first.indexOf('/');
+    return slash > 0 ? first.slice(0, slash) : files.length + ' files';
+  }
+
+  function tokenOf(el) {
+    const cls = Array.from(el.classList).find((c) => c.indexOf('vpinfe-dnd-') === 0);
+    return cls ? cls.slice('vpinfe-dnd-'.length) : null;
+  }
+
+  function attachEl(el) {
+    if (!el || el.dataset.vpinfeDndBound) return;
+    const token = tokenOf(el);
+    if (!token) return;
+    el.dataset.vpinfeDndBound = '1';
+    const activate = (on) => el.classList.toggle('dnd-drop-zone--active', on);
+
+    el.addEventListener('dragenter', (e) => { e.preventDefault(); activate(true); });
+    el.addEventListener('dragover', (e) => { e.preventDefault(); activate(true); });
+    el.addEventListener('dragleave', (e) => { if (e.target === el) activate(false); });
+    el.addEventListener('drop', async (e) => {
+      e.preventDefault();
+      activate(false);
+      try {
+        const files = await collectFiles(e.dataTransfer);
+        if (!files.length) {
+          emit({ token: token, status: 'error', message: 'No files found in the drop' });
+          return;
+        }
+        emit({ token: token, status: 'progress', done: 0, total: files.length, name: '' });
+        const result = await uploadAll(token, files);
+        emit({
+          token: token, status: 'done', upload_id: result.uploadId,
+          file_count: result.info.file_count, total_bytes: result.info.total_bytes,
+          name: rootName(files),
+        });
+      } catch (err) {
+        emit({ token: token, status: 'error', message: String((err && err.message) || err) });
+      }
+    });
+  }
+
+  function rowsTokenOf(el) {
+    const cls = Array.from(el.classList).find((c) => c.indexOf('vpinfe-dnd-rows-') === 0);
+    return cls ? cls.slice('vpinfe-dnd-rows-'.length) : null;
+  }
+
+  function attachRowContainer(el) {
+    if (!el || el.dataset.vpinfeDndRowsBound) return;
+    const token = rowsTokenOf(el);
+    if (!token) return;
+    el.dataset.vpinfeDndRowsBound = '1';
+
+    const rowOf = (target) => {
+      const row = target && target.closest ? target.closest('tr') : null;
+      return row && row.querySelector('[data-drop-filename]') ? row : null;
+    };
+    const clearHighlight = () => {
+      el.querySelectorAll('tr.dnd-row-active').forEach((r) => r.classList.remove('dnd-row-active'));
+    };
+
+    el.addEventListener('dragover', (e) => {
+      const row = rowOf(e.target);
+      if (!row) { clearHighlight(); return; }
+      e.preventDefault();
+      if (!row.classList.contains('dnd-row-active')) {
+        clearHighlight();
+        row.classList.add('dnd-row-active');
+      }
+    });
+    el.addEventListener('dragleave', (e) => {
+      if (e.target === el || !el.contains(e.relatedTarget)) clearHighlight();
+    });
+    el.addEventListener('drop', async (e) => {
+      const row = rowOf(e.target);
+      clearHighlight();
+      if (!row) return;
+      e.preventDefault();
+      const rowKey = row.querySelector('[data-drop-filename]').getAttribute('data-drop-filename');
+      try {
+        const files = await collectFiles(e.dataTransfer);
+        if (!files.length) {
+          emit({ token: token, status: 'error', message: 'No files found in the drop' });
+          return;
+        }
+        emit({ token: token, status: 'progress', done: 0, total: files.length, name: '' });
+        const result = await uploadAll(token, files);
+        emit({
+          token: token, status: 'done', upload_id: result.uploadId, row_key: rowKey,
+          file_count: result.info.file_count, total_bytes: result.info.total_bytes,
+          name: rootName(files),
+        });
+      } catch (err) {
+        emit({ token: token, status: 'error', message: String((err && err.message) || err) });
+      }
+    });
+  }
+
+  function cellsTokenOf(el) {
+    const cls = Array.from(el.classList).find((c) => c.indexOf('vpinfe-dnd-cells-') === 0);
+    return cls ? cls.slice('vpinfe-dnd-cells-'.length) : null;
+  }
+
+  function attachCellContainer(el) {
+    if (!el || el.dataset.vpinfeDndCellsBound) return;
+    const token = cellsTokenOf(el);
+    if (!token) return;
+    el.dataset.vpinfeDndCellsBound = '1';
+
+    const cellOf = (target) =>
+      target && target.closest ? target.closest('td[data-drop-media-key]') : null;
+    const clearHighlight = () => {
+      el.querySelectorAll('td.dnd-cell-active').forEach((c) => c.classList.remove('dnd-cell-active'));
+    };
+
+    el.addEventListener('dragover', (e) => {
+      const cell = cellOf(e.target);
+      if (!cell) { clearHighlight(); return; }
+      e.preventDefault();
+      if (!cell.classList.contains('dnd-cell-active')) {
+        clearHighlight();
+        cell.classList.add('dnd-cell-active');
+      }
+    });
+    el.addEventListener('dragleave', (e) => {
+      if (e.target === el || !el.contains(e.relatedTarget)) clearHighlight();
+    });
+    el.addEventListener('drop', async (e) => {
+      const cell = cellOf(e.target);
+      clearHighlight();
+      if (!cell) return;
+      e.preventDefault();
+      const mediaKey = cell.getAttribute('data-drop-media-key');
+      const rowKey = cell.getAttribute('data-drop-media-row');
+      try {
+        const files = await collectFiles(e.dataTransfer);
+        if (!files.length) {
+          emit({ token: token, status: 'error', message: 'No files found in the drop' });
+          return;
+        }
+        emit({ token: token, status: 'progress', done: 0, total: files.length, name: '' });
+        const result = await uploadAll(token, files);
+        emit({
+          token: token, status: 'done', upload_id: result.uploadId,
+          cell_row: rowKey, cell_media_key: mediaKey,
+          file_count: result.info.file_count, total_bytes: result.info.total_bytes,
+          name: rootName(files),
+        });
+      } catch (err) {
+        emit({ token: token, status: 'error', message: String((err && err.message) || err) });
+      }
+    });
+  }
+
+  // Auto-attach: bind any drop zone present now and whenever one is added to the DOM.
+  // This survives NiceGUI re-renders and websocket reconnects without a server-side timer.
+  function scan() {
+    document.querySelectorAll('.dnd-drop-zone').forEach(attachEl);
+    document.querySelectorAll('[class*="vpinfe-dnd-rows-"]').forEach(attachRowContainer);
+    document.querySelectorAll('[class*="vpinfe-dnd-cells-"]').forEach(attachCellContainer);
+  }
+
+  scan();
+  const observer = new MutationObserver((mutations) => {
+    for (const mutation of mutations) {
+      if (mutation.addedNodes && mutation.addedNodes.length) {
+        scan();
+        return;
+      }
+    }
+  });
+  observer.observe(document.documentElement, { childList: true, subtree: true });
+
+  window.vpinfeDnd = { scan: scan, attach: attachEl };
+})();

--- a/managerui/upload_api.py
+++ b/managerui/upload_api.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from fastapi import APIRouter, Body, File, Form, UploadFile
+from fastapi.responses import JSONResponse
+from starlette.concurrency import run_in_threadpool
+
+from managerui.services import upload_session_service
+from managerui.services.asset_analyzer_service import AnalysisResult, DetectedAsset, analyze_upload_session
+from managerui.services.asset_import_service import (
+    ImportPlan,
+    build_import_plan,
+    execute_import_plan,
+    find_vps_entry,
+    select_plan_items,
+    vps_folder_name,
+)
+from managerui.services.asset_registry import spec_for
+from managerui.services.upload_session_service import UnknownSession, UnsafePath, UploadTooLarge
+
+
+logger = logging.getLogger("vpinfe.manager.upload_api")
+
+router = APIRouter()
+
+
+def _asset_to_dict(asset: DetectedAsset) -> dict:
+    return {
+        "kind": asset.kind,
+        "label": asset.label,
+        "media_key": asset.media_key,
+        "root": asset.root,
+        "size": asset.size,
+        "detail": asset.detail,
+    }
+
+
+def _analysis_to_dict(analysis: AnalysisResult) -> dict:
+    return {
+        "source_kind": analysis.source_kind,
+        "source_name": analysis.source_name,
+        "has_table": analysis.has_table,
+        "assets": [_asset_to_dict(a) for a in analysis.assets],
+        "notes": list(analysis.notes),
+        "error": analysis.error,
+        "unrecognized": list(analysis.unrecognized),
+        "bundle_info": analysis.bundle_info,
+    }
+
+
+def _plan_to_dict(plan: ImportPlan) -> dict:
+    return {
+        "table_path": plan.table_path,
+        "new_table_dir_name": plan.new_table_dir_name,
+        "rom_name": plan.rom_name,
+        "items": [
+            {
+                "index": index,
+                "kind": item.asset.kind,
+                "label": spec_for(item.asset.kind).label,
+                "detail": item.asset.detail,
+                "destination": item.destination,
+                "action": item.action,
+                "default_enabled": item.default_enabled,
+                "size": item.asset.size,
+                "media_key": item.asset.media_key,
+            }
+            for index, item in enumerate(plan.items)
+        ],
+        "blocked": [{"kind": b.asset.kind, "reason": b.reason} for b in plan.blocked],
+    }
+
+
+@router.post("/api/asset-upload/begin")
+def asset_upload_begin() -> JSONResponse:
+    session = upload_session_service.begin_session()
+    return JSONResponse({"upload_id": session.upload_id})
+
+
+@router.post("/api/asset-upload/file")
+async def asset_upload_file(upload_id: str = Form(...), relpath: str = Form(...),
+                            file: UploadFile = File(...)) -> JSONResponse:
+    try:
+        written = await run_in_threadpool(
+            upload_session_service.store_file, upload_id, relpath, file.file)
+    except UploadTooLarge as exc:
+        return JSONResponse({"error": str(exc)}, status_code=413)
+    except (UnknownSession, UnsafePath) as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
+    return JSONResponse({"bytes": written})
+
+
+@router.post("/api/asset-upload/finish")
+def asset_upload_finish(upload_id: str = Form(...)) -> JSONResponse:
+    try:
+        info = upload_session_service.finish_session(upload_id)
+    except UnknownSession as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
+    return JSONResponse(info)
+
+
+@router.post("/api/asset-upload/abort")
+def asset_upload_abort(upload_id: str = Form(...)) -> JSONResponse:
+    upload_session_service.cleanup_session(upload_id)
+    return JSONResponse({"ok": True})
+
+
+# --- Analysis / import over HTTP (transport-neutral; drivable without the UI) ----
+
+def _session_or_error(upload_id: str):
+    try:
+        return upload_session_service.get_session_dir(upload_id), None
+    except UnknownSession as exc:
+        return None, JSONResponse({"error": str(exc)}, status_code=400)
+
+
+@router.post("/api/asset-upload/analyze")
+def asset_upload_analyze(payload: dict = Body(...)) -> JSONResponse:
+    session_dir, error = _session_or_error(payload.get("upload_id", ""))
+    if error is not None:
+        return error
+    analysis, _source = analyze_upload_session(session_dir)
+    return JSONResponse(_analysis_to_dict(analysis))
+
+
+def _resolve_vps(payload: dict):
+    """Return (vps_entry | None, error_response | None) for an optional vps_id."""
+    vps_id = (payload.get("vps_id") or "").strip()
+    if not vps_id:
+        return None, None
+    entry = find_vps_entry(vps_id)
+    if entry is None:
+        return None, JSONResponse({"error": f"Unknown vps_id: {vps_id}"}, status_code=400)
+    return entry, None
+
+
+@router.post("/api/asset-upload/vps-search")
+def asset_upload_vps_search(payload: dict = Body(...)) -> JSONResponse:
+    from managerui.services.table_service import search_vpsdb
+
+    results = search_vpsdb(payload.get("q", ""), limit=int(payload.get("limit", 20)))
+    return JSONResponse({
+        "results": [
+            {
+                "vps_id": e.get("id"),
+                "name": e.get("name"),
+                "manufacturer": e.get("manufacturer"),
+                "year": e.get("year"),
+                "type": e.get("type"),
+                "folder_name": vps_folder_name(e),
+            }
+            for e in results
+        ]
+    })
+
+
+@router.post("/api/asset-upload/plan")
+def asset_upload_plan(payload: dict = Body(...)) -> JSONResponse:
+    session_dir, error = _session_or_error(payload.get("upload_id", ""))
+    if error is not None:
+        return error
+    vps_entry, error = _resolve_vps(payload)
+    if error is not None:
+        return error
+    analysis, _source = analyze_upload_session(session_dir)
+    if analysis.error:
+        return JSONResponse({"error": analysis.error}, status_code=422)
+    plan = build_import_plan(
+        analysis,
+        table_path=payload.get("table_path", ""),
+        rom_name=payload.get("rom_name", ""),
+        allow_new_table=bool(payload.get("allow_new_table", False)),
+    )
+    if vps_entry is not None and plan.new_table_dir_name:
+        plan = select_plan_items(plan, None, vps_folder_name(vps_entry))
+    return JSONResponse(_plan_to_dict(plan))
+
+
+@router.post("/api/asset-upload/import")
+def asset_upload_import(payload: dict = Body(...)) -> JSONResponse:
+    upload_id = payload.get("upload_id", "")
+    session_dir, error = _session_or_error(upload_id)
+    if error is not None:
+        return error
+    vps_entry, error = _resolve_vps(payload)
+    if error is not None:
+        return error
+    analysis, source_path = analyze_upload_session(session_dir)
+    if analysis.error:
+        return JSONResponse({"error": analysis.error}, status_code=422)
+    plan = build_import_plan(
+        analysis,
+        table_path=payload.get("table_path", ""),
+        rom_name=payload.get("rom_name", ""),
+        allow_new_table=bool(payload.get("allow_new_table", False)),
+    )
+    if vps_entry is not None and not plan.new_table_dir_name:
+        return JSONResponse({"error": "vps_id only applies to new-table imports"}, status_code=400)
+    # Folder naming precedence: explicit new_table_dir_name > VPS-derived > vpx stem.
+    new_name = payload.get("new_table_dir_name")
+    if new_name is None and vps_entry is not None:
+        new_name = vps_folder_name(vps_entry)
+    try:
+        plan = select_plan_items(plan, payload.get("selected"), new_name)
+    except ValueError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
+
+    blocked = [{"kind": b.asset.kind, "reason": b.reason} for b in plan.blocked]
+    if not plan.items:
+        return JSONResponse({"error": "No importable assets", "blocked": blocked}, status_code=422)
+    try:
+        report = execute_import_plan(plan, source_path)
+    except (ValueError, FileNotFoundError) as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
+    upload_session_service.cleanup_session(upload_id)
+    report["blocked"] = blocked
+
+    if vps_entry is not None and report.get("new_table"):
+        # Files are on disk; association failure is reported, not fatal.
+        from managerui.services.table_service import associate_vps_to_folder, build_metadata
+
+        try:
+            associate_vps_to_folder(Path(report["table_path"]), vps_entry, True)
+            build_metadata(downloadMedia=True, updateAll=True,
+                          tableName=Path(report["table_path"]).name)
+            report["vps_associated"] = True
+        except Exception as exc:
+            logger.exception("VPS association failed after import")
+            report["vps_associated"] = False
+            report["vps_error"] = str(exc)
+    return JSONResponse(report)
+
+
+def register_routes(app) -> None:
+    """Attach the asset-upload routes to the given FastAPI app."""
+    app.include_router(router)

--- a/osx_requirements.txt
+++ b/osx_requirements.txt
@@ -7,4 +7,6 @@ nicegui
 platformdirs
 pillow
 psutil
+rarfile
+py7zr
 pyobjc; sys_platform == "darwin"

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,8 @@ platformdirs
 pillow
 qrcode
 psutil
+rarfile
+py7zr
 
 # Platform-specific dependencies (installed conditionally)
 # pyobjc; sys_platform == "darwin"

--- a/tests/test_asset_upload_services.py
+++ b/tests/test_asset_upload_services.py
@@ -1,0 +1,787 @@
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+from managerui.services import asset_analyzer_service, asset_import_service, upload_session_service
+from managerui.services.asset_analyzer_service import analyze_path, analyze_upload_session
+from managerui.services.asset_import_service import (
+    build_import_plan,
+    build_media_slot_plan,
+    execute_import_plan,
+    find_vps_entry,
+    merge_info,
+    select_plan_items,
+    vps_folder_name,
+    _safe_dest,
+)
+from managerui.services.asset_registry import (
+    classify_bare_extension,
+    match_media_key,
+    spec_for,
+)
+
+
+def _make_zip(path, names):
+    import zipfile
+    with zipfile.ZipFile(path, "w") as archive:
+        for name in names:
+            archive.writestr(name, b"x" * 16)
+
+
+def _kinds(result):
+    return sorted(asset.kind for asset in result.assets)
+
+
+class AssetRegistryTests(unittest.TestCase):
+    def test_classify_bare_extension(self):
+        cases = [
+            ("Medieval Madness.vpx", "table"),
+            ("Medieval Madness.directb2s", "backglass"),
+            ("mm_105b.crz", "altcolor_serum"),
+            ("mm_105b.CRZ", "altcolor_serum"),
+            ("mm_105b.vni", "altcolor_vni"),
+            ("mm_105b.PAL", "altcolor_vni"),
+            ("mm_105b.pac", "altcolor_vni"),
+            ("Medieval Madness.ini", "ini"),
+            ("wheel.png", "media"),
+            ("bg.mp4", "media"),
+            ("audio.mp3", "media"),
+            ("roms.zip", None),        # archives are inspected, not bare-classified
+            ("pack.7z", None),
+            ("readme.txt", None),
+            ("noext", None),
+        ]
+        for filename, expected in cases:
+            with self.subTest(filename=filename):
+                spec = classify_bare_extension(filename)
+                self.assertEqual(spec.key if spec else None, expected)
+
+    def test_match_media_key_canonical_names(self):
+        cases = [
+            ("bg.png", "bg"),
+            ("dmd.png", "dmd"),
+            ("dmd.mp4", "dmd_video"),
+            ("table.png", "table"),
+            ("table.mp4", "table_video"),
+            ("wheel.png", "wheel"),
+            ("audio.mp3", "audio"),
+            ("realdmd-color.png", "realdmd_color"),
+        ]
+        for filename, expected in cases:
+            with self.subTest(filename=filename):
+                self.assertEqual(match_media_key(filename), expected)
+
+    def test_match_media_key_keyword_fallback(self):
+        cases = [
+            ("MyTable_wheel.png", "wheel"),
+            ("Table_backglass.png", "bg"),
+            ("Game_dmd.mp4", "dmd_video"),
+            ("realdmd.png", "realdmd"),
+            ("song.mp3", "audio"),        # any recognized audio file -> audio slot
+            ("photo.png", None),          # no keyword -> unrecognized
+            ("notes.txt", None),          # non-media extension
+        ]
+        for filename, expected in cases:
+            with self.subTest(filename=filename):
+                self.assertEqual(match_media_key(filename), expected)
+
+    def test_realdmd_not_claimed_by_dmd_rule(self):
+        # "realdmd" contains "dmd"; the realdmd rule must win, and a realdmd video
+        # (no such slot) must not fall through to dmd_video.
+        self.assertEqual(match_media_key("realdmd.png"), "realdmd")
+        self.assertIsNone(match_media_key("realdmd.mp4"))
+
+    def test_spec_for_flags(self):
+        self.assertFalse(spec_for("table").requires_table)
+        self.assertTrue(spec_for("backglass").requires_table)
+        self.assertTrue(spec_for("altcolor_serum").requires_rom)
+        self.assertFalse(spec_for("pup_pack").requires_rom)
+        self.assertTrue(spec_for("media").allow_multiple)
+        with self.assertRaises(KeyError):
+            spec_for("nonexistent")
+
+
+class AssetAnalyzerTests(unittest.TestCase):
+    def test_table_bundle(self):
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as tmp:
+            zip_path = Path(tmp) / "bundle.zip"
+            _make_zip(zip_path, ["Foo.vpx", "Foo.directb2s", "Foo.ini"])
+            result = analyze_path(zip_path)
+            self.assertTrue(result.has_table)
+            self.assertEqual(_kinds(result), ["backglass", "ini", "table"])
+            self.assertEqual(result.error, "")
+
+    def test_pup_marker_and_root(self):
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as tmp:
+            zip_path = Path(tmp) / "pup.zip"
+            _make_zip(zip_path, ["MyPup/screens.pup", "MyPup/S1/a.mp4", "MyPup/S2/b.mp4"])
+            result = analyze_path(zip_path)
+            self.assertEqual(_kinds(result), ["pup_pack"])
+            self.assertEqual(result.assets[0].root, "MyPup")
+            self.assertEqual(len(result.assets[0].entries), 3)
+
+    def test_pup_fallback_by_shape(self):
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        names = [f"Pack/screen{i}/clip.mp4" for i in range(12)]
+        with TemporaryDirectory() as tmp:
+            zip_path = Path(tmp) / "shape.zip"
+            _make_zip(zip_path, names)
+            result = analyze_path(zip_path)
+            self.assertEqual(_kinds(result), ["pup_pack"])
+            self.assertEqual(result.assets[0].root, "Pack")
+
+    def test_altsound_nested_marker(self):
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as tmp:
+            zip_path = Path(tmp) / "as.zip"
+            _make_zip(zip_path, ["altsound/altsound.csv", "altsound/1/x.ogg", "altsound/2/y.ogg"])
+            result = analyze_path(zip_path)
+            self.assertEqual(_kinds(result), ["altsound"])
+            self.assertEqual(result.assets[0].root, "altsound")
+
+    def test_flat_rom_archive(self):
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as tmp:
+            zip_path = Path(tmp) / "rom.zip"
+            _make_zip(zip_path, ["mm_105.bin", "mm_snd.u7", "mm.cpu"])
+            result = analyze_path(zip_path)
+            self.assertEqual(_kinds(result), ["rom"])
+            self.assertEqual(len(result.assets[0].entries), 3)
+
+    def test_nested_zip_is_rom_blob(self):
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        import io
+        import zipfile
+        with TemporaryDirectory() as tmp:
+            zip_path = Path(tmp) / "nested.zip"
+            inner = io.BytesIO()
+            with zipfile.ZipFile(inner, "w") as iz:
+                iz.writestr("a.bin", b"x")
+            with zipfile.ZipFile(zip_path, "w") as archive:
+                archive.writestr("Foo.vpx", b"x")
+                archive.writestr("roms/mm.zip", inner.getvalue())
+            result = analyze_path(zip_path)
+            self.assertEqual(_kinds(result), ["rom", "table"])
+
+    def test_music_folder(self):
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as tmp:
+            zip_path = Path(tmp) / "music.zip"
+            _make_zip(zip_path, ["music/song1.mp3", "music/song2.ogg"])
+            result = analyze_path(zip_path)
+            self.assertEqual(_kinds(result), ["music"])
+            self.assertEqual(result.assets[0].root, "music")
+
+    def test_music_with_video_is_not_music(self):
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as tmp:
+            zip_path = Path(tmp) / "mv.zip"
+            _make_zip(zip_path, ["stuff/song1.mp3", "stuff/clip.mp4"])
+            result = analyze_path(zip_path)
+            self.assertNotIn("music", _kinds(result))
+
+    def test_junk_entries_skipped(self):
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as tmp:
+            zip_path = Path(tmp) / "junk.zip"
+            _make_zip(zip_path, ["Foo.vpx", "__MACOSX/._Foo.vpx", ".DS_Store"])
+            result = analyze_path(zip_path)
+            self.assertEqual(_kinds(result), ["table"])
+
+    def test_unrecognized_only_is_error(self):
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as tmp:
+            zip_path = Path(tmp) / "empty.zip"
+            _make_zip(zip_path, ["readme.txt", "notes.md"])
+            result = analyze_path(zip_path)
+            self.assertEqual(result.assets, ())
+            self.assertTrue(result.error)
+
+    def test_dir_source_parity_with_zip(self):
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        import zipfile
+        names = ["Foo.vpx", "MyPup/screens.pup", "MyPup/s1/a.mp4"]
+        with TemporaryDirectory() as tmp:
+            zip_path = Path(tmp) / "parity.zip"
+            _make_zip(zip_path, names)
+            from_zip = sorted((a.kind, a.root) for a in analyze_path(zip_path).assets)
+            tree = Path(tmp) / "tree"
+            with zipfile.ZipFile(zip_path) as archive:
+                archive.extractall(tree)
+            from_dir = sorted((a.kind, a.root) for a in analyze_path(tree).assets)
+            self.assertEqual(from_zip, from_dir)
+
+    def test_single_bare_files(self):
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as tmp:
+            wheel = Path(tmp) / "wheel.png"
+            wheel.write_bytes(b"x")
+            result = analyze_path(wheel)
+            self.assertEqual(_kinds(result), ["media"])
+            self.assertEqual(result.assets[0].media_key, "wheel")
+
+    def test_rar_tool_hint_is_platform_aware(self):
+        from managerui.services.asset_analyzer_service import rar_tool_hint
+        with mock.patch.object(asset_analyzer_service.sys, "platform", "win32"):
+            self.assertIn("UnRAR.exe", rar_tool_hint())
+        with mock.patch.object(asset_analyzer_service.sys, "platform", "darwin"):
+            self.assertIn("brew install unar", rar_tool_hint())
+        with mock.patch.object(asset_analyzer_service.sys, "platform", "linux"):
+            hint = rar_tool_hint()
+            self.assertIn("package manager", hint)
+            self.assertNotIn("apt", hint)   # never assume a specific distro's tool
+        self.assertIn("Configuration", rar_tool_hint())   # points at the configurable path
+
+    def test_configure_rar_tool_targets_right_global(self):
+        from managerui.services.asset_analyzer_service import configure_rar_tool
+        fake = mock.Mock()
+        with mock.patch.object(asset_analyzer_service, "rarfile", fake):
+            configure_rar_tool("/opt/bin/unar")
+            self.assertEqual(fake.UNAR_TOOL, "/opt/bin/unar")
+            configure_rar_tool("/usr/bin/unrar")
+            self.assertEqual(fake.UNRAR_TOOL, "/usr/bin/unrar")
+        # empty path is a no-op (keeps rarfile's PATH auto-detect)
+        with mock.patch.object(asset_analyzer_service, "rarfile", None):
+            configure_rar_tool("")   # must not raise when rarfile is absent
+
+    def test_missing_rar_tool_reported_before_dialog(self):
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as tmp:
+            fake_rar = Path(tmp) / "x.rar"
+            fake_rar.write_bytes(b"x")
+            with mock.patch.object(asset_analyzer_service, "open_source") as fake_open, \
+                    mock.patch.object(asset_analyzer_service, "rar_tool_available", return_value=False):
+                fake_open.return_value = mock.Mock(kind="rar", name="x.rar")
+                result = analyze_path(fake_rar)
+            self.assertEqual(result.assets, ())
+            self.assertIn("unar", result.error)
+
+    def test_rar_backend_missing_is_graceful(self):
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as tmp:
+            fake_rar = Path(tmp) / "x.rar"
+            fake_rar.write_bytes(b"not really a rar")
+            with mock.patch.object(asset_analyzer_service, "rarfile", None):
+                result = analyze_path(fake_rar)
+            self.assertEqual(result.assets, ())
+            self.assertIn("rarfile", result.error)
+
+    def test_upload_session_single_archive(self):
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as tmp:
+            session = Path(tmp) / "session"
+            session.mkdir()
+            _make_zip(session / "bundle.zip", ["Foo.vpx"])
+            result, source_path = analyze_upload_session(session)
+            self.assertEqual(_kinds(result), ["table"])
+            self.assertEqual(source_path.name, "bundle.zip")
+
+    def test_upload_session_folder(self):
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as tmp:
+            session = Path(tmp) / "session"
+            (session / "MyPup").mkdir(parents=True)
+            (session / "MyPup" / "screens.pup").write_bytes(b"x")
+            (session / "Foo.vpx").write_bytes(b"x")
+            result, source_path = analyze_upload_session(session)
+            self.assertEqual(_kinds(result), ["pup_pack", "table"])
+            self.assertEqual(source_path, session)
+
+
+def _plan_kinds_by_action(plan):
+    return {item.asset.kind: item.action for item in plan.items}
+
+
+def _blocked_reasons(plan):
+    return {item.asset.kind: item.reason for item in plan.blocked}
+
+
+class ImportPlanTests(unittest.TestCase):
+    def test_new_table_bundle_routes_vpx_and_blocks_rom_color(self):
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as tmp:
+            zip_path = Path(tmp) / "Medieval Madness.zip"
+            _make_zip(zip_path, ["Medieval Madness.vpx", "Medieval Madness.directb2s", "mm.crz"])
+            analysis = analyze_path(zip_path)
+            plan = build_import_plan(analysis, allow_new_table=True, tables_path=tmp)
+            self.assertEqual(plan.new_table_dir_name, "Medieval Madness")
+            actions = _plan_kinds_by_action(plan)
+            self.assertEqual(actions["table"], "copy")
+            self.assertEqual(actions["backglass"], "replace_b2s")
+            # serum color needs a ROM name the fresh table doesn't have yet
+            self.assertIn("altcolor_serum", _blocked_reasons(plan))
+
+    def test_existing_table_routing(self):
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as tmp:
+            table_dir = Path(tmp) / "Foo (Bar 1999)"
+            table_dir.mkdir()
+            (table_dir / "Foo.vpx").write_bytes(b"x")
+            zip_path = Path(tmp) / "assets.zip"
+            _make_zip(zip_path, ["new.vpx", "MyPup/screens.pup", "MyPup/s1/a.mp4", "wheel.png"])
+            analysis = analyze_path(zip_path)
+            plan = build_import_plan(analysis, table_path=str(table_dir), rom_name="mm")
+            actions = _plan_kinds_by_action(plan)
+            self.assertEqual(actions["table"], "replace_vpx")
+            self.assertEqual(actions["pup_pack"], "extract_tree")
+            self.assertEqual(actions["media"], "replace_media")
+
+    def test_no_context_blocks_all(self):
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as tmp:
+            wheel = Path(tmp) / "wheel.png"
+            wheel.write_bytes(b"x")
+            analysis = analyze_path(wheel)
+            plan = build_import_plan(analysis)
+            self.assertEqual(plan.items, ())
+            self.assertIn("media", _blocked_reasons(plan))
+
+
+class SelectPlanItemsTests(unittest.TestCase):
+    def _bundle_plan(self, tmp):
+        from pathlib import Path
+        zip_path = Path(tmp) / "Medieval Madness.zip"
+        _make_zip(zip_path, ["Medieval Madness.vpx", "wheel.png", "MyPup/screens.pup", "MyPup/s/a.mp4"])
+        analysis = analyze_path(zip_path)
+        return build_import_plan(analysis, allow_new_table=True, tables_path=tmp)
+
+    def test_none_keeps_all_items(self):
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as tmp:
+            plan = self._bundle_plan(tmp)
+            self.assertEqual(len(select_plan_items(plan).items), len(plan.items))
+
+    def test_indices_filter_items(self):
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as tmp:
+            plan = self._bundle_plan(tmp)
+            narrowed = select_plan_items(plan, indices=[0])
+            self.assertEqual(len(narrowed.items), 1)
+            self.assertEqual(narrowed.items[0].asset.kind, "table")
+
+    def test_rename_rebases_destinations(self):
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as tmp:
+            plan = self._bundle_plan(tmp)
+            renamed = select_plan_items(plan, new_table_dir_name="Renamed MM")
+            self.assertEqual(renamed.new_table_dir_name, "Renamed MM")
+            for item in renamed.items:
+                self.assertIn("/Renamed MM/", item.destination)
+
+    def test_blank_rename_raises(self):
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as tmp:
+            plan = self._bundle_plan(tmp)
+            with self.assertRaises(ValueError):
+                select_plan_items(plan, new_table_dir_name='<>:"/\\|?*')
+
+
+class MediaSlotPlanTests(unittest.TestCase):
+    def test_family_validation(self):
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as tmp:
+            for filename, media_key, ok in [
+                ("art.png", "wheel", True),
+                ("art.jpg", "bg", True),
+                ("clip.mp4", "dmd_video", True),
+                ("song.mp3", "audio", True),
+                ("art.png", "dmd_video", False),   # image into a video slot
+                ("clip.mp4", "wheel", False),      # video into an image slot
+                ("song.mp3", "bg", False),
+            ]:
+                with self.subTest(filename=filename, media_key=media_key):
+                    src = Path(tmp) / filename
+                    src.write_bytes(b"x")
+                    plan = build_media_slot_plan(src, table_path=tmp, media_key=media_key)
+                    if ok:
+                        self.assertEqual(len(plan.items), 1)
+                        self.assertEqual(plan.items[0].action, "replace_media")
+                        self.assertEqual(plan.items[0].asset.media_key, media_key)
+                    else:
+                        self.assertEqual(plan.items, ())
+                        self.assertTrue(plan.blocked)
+
+    def test_archive_and_unknown_slot_rejected(self):
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as tmp:
+            archive = Path(tmp) / "pack.zip"
+            archive.write_bytes(b"x")
+            plan = build_media_slot_plan(archive, table_path=tmp, media_key="wheel")
+            self.assertEqual(plan.items, ())
+            with self.assertRaises(ValueError):
+                build_media_slot_plan(archive, table_path=tmp, media_key="not_a_slot")
+
+    def test_execute_slot_plan_calls_replace(self):
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as tmp:
+            table_dir = Path(tmp) / "Foo (Bar 1999)"
+            table_dir.mkdir()
+            src = Path(tmp) / "cool-art.png"
+            src.write_bytes(b"png-bytes")
+            plan = build_media_slot_plan(src, table_path=str(table_dir), media_key="wheel")
+            with mock.patch("managerui.services.asset_import_service.replace_media_file") as fake:
+                report = execute_import_plan(plan, src)
+            self.assertEqual(fake.call_args.args[2], "wheel")
+            self.assertEqual(report["media_keys"], ["wheel"])
+
+
+class TableInfoDetectionTests(unittest.TestCase):
+    def test_info_beside_vpx_is_claimed_and_parsed(self):
+        import json
+        import zipfile
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        info = {"Info": {"VPSId": "abc123"}, "User": {"Rating": 4}}
+        with TemporaryDirectory() as tmp:
+            zip_path = Path(tmp) / "bundle.zip"
+            with zipfile.ZipFile(zip_path, "w") as archive:
+                archive.writestr("Foo (Bar 1999)/Foo.vpx", b"x")
+                archive.writestr("Foo (Bar 1999)/Foo (Bar 1999).info", json.dumps(info))
+            result = analyze_path(zip_path)
+            self.assertIn("table_info", _kinds(result))
+            self.assertEqual(result.bundle_info["Info"]["VPSId"], "abc123")
+
+    def test_lone_info_stays_unrecognized(self):
+        import json
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as tmp:
+            info_file = Path(tmp) / "Foo.info"
+            info_file.write_text(json.dumps({"Info": {}}))
+            result = analyze_path(info_file)
+            self.assertNotIn("table_info", _kinds(result))
+
+    def test_invalid_info_is_dropped_with_note(self):
+        import zipfile
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as tmp:
+            zip_path = Path(tmp) / "bundle.zip"
+            with zipfile.ZipFile(zip_path, "w") as archive:
+                archive.writestr("Foo.vpx", b"x")
+                archive.writestr("Foo.info", b"this is not json {{{")
+            result = analyze_path(zip_path)
+            self.assertNotIn("table_info", _kinds(result))
+            self.assertIsNone(result.bundle_info)
+            self.assertIn("Foo.info", result.unrecognized)
+
+
+class MergeInfoTests(unittest.TestCase):
+    def test_info_adopted_only_when_unmatched(self):
+        incoming = {"Info": {"VPSId": "new1", "Title": "New"}}
+        self.assertEqual(merge_info(incoming, {})["Info"]["VPSId"], "new1")
+        self.assertEqual(
+            merge_info(incoming, {"Info": {"VPSId": "old1"}})["Info"]["VPSId"], "old1")
+
+    def test_user_fills_gaps_never_replaces(self):
+        incoming = {"User": {"Rating": 4, "StartCount": 300, "Tags": ["fav"]}}
+        existing = {"User": {"Rating": 0, "StartCount": 7, "Tags": []}}
+        merged = merge_info(incoming, existing)["User"]
+        self.assertEqual(merged["Rating"], 4)        # local was empty -> filled
+        self.assertEqual(merged["StartCount"], 7)    # local had history -> kept
+        self.assertEqual(merged["Tags"], ["fav"])    # local empty list -> filled
+
+    def test_vpxfile_and_medias_always_local(self):
+        incoming = {"VPXFile": {"filename": "old.vpx"}, "Medias": {"wheel": "/old/path"}}
+        existing = {"VPXFile": {"filename": "local.vpx"}, "Medias": {}}
+        merged = merge_info(incoming, existing)
+        self.assertEqual(merged["VPXFile"]["filename"], "local.vpx")
+        self.assertEqual(merged["Medias"], {})
+
+    def test_machine_local_overrides_must_resolve(self):
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as tmp:
+            real_launcher = Path(tmp) / "vpx-custom"
+            real_launcher.write_bytes(b"x")
+            incoming = {"VPinFE": {"altlauncher": "/nonexistent/vpx", "alttitle": "Cool Name"}}
+            merged = merge_info(incoming, {"VPinFE": {"altlauncher": "", "alttitle": ""}})
+            self.assertEqual(merged["VPinFE"]["altlauncher"], "")   # dropped, does not resolve
+            self.assertEqual(merged["VPinFE"]["alttitle"], "Cool Name")
+            incoming2 = {"VPinFE": {"altlauncher": str(real_launcher)}}
+            merged2 = merge_info(incoming2, {"VPinFE": {"altlauncher": ""}})
+            self.assertEqual(merged2["VPinFE"]["altlauncher"], str(real_launcher))
+
+    def test_unknown_sections_added_not_replaced(self):
+        incoming = {"CustomTool": {"a": 1}, "Shared": {"x": "incoming"}}
+        existing = {"Shared": {"x": "local"}}
+        merged = merge_info(incoming, existing)
+        self.assertEqual(merged["CustomTool"], {"a": 1})
+        self.assertEqual(merged["Shared"]["x"], "local")
+
+
+class TableInfoImportTests(unittest.TestCase):
+    def _bundle(self, tmp, info: dict):
+        import json
+        import zipfile
+        from pathlib import Path
+        zip_path = Path(tmp) / "bundle.zip"
+        with zipfile.ZipFile(zip_path, "w") as archive:
+            archive.writestr("Old Name (Mfg 1999).vpx", b"x")
+            archive.writestr("Old Name (Mfg 1999).info", json.dumps(info))
+        return zip_path
+
+    def test_new_table_adopts_and_renames_info(self):
+        import json
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        with mock.patch.object(asset_import_service, "refresh_table"):
+            with TemporaryDirectory() as tmp:
+                zip_path = self._bundle(tmp, {"Info": {"VPSId": "abc"}, "User": {"Rating": 5}})
+                analysis = analyze_path(zip_path)
+                plan = build_import_plan(analysis, allow_new_table=True, tables_path=tmp)
+                plan = select_plan_items(plan, None, "New Name (Mfg 2000)")
+                execute_import_plan(plan, zip_path)
+                dest = Path(tmp) / "New Name (Mfg 2000)" / "New Name (Mfg 2000).info"
+                self.assertTrue(dest.exists())
+                data = json.loads(dest.read_text())
+                self.assertEqual(data["User"]["Rating"], 5)
+
+    def test_existing_table_merges_and_backs_up(self):
+        import json
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        with mock.patch.object(asset_import_service, "refresh_table"):
+            with TemporaryDirectory() as tmp:
+                table_dir = Path(tmp) / "Foo (Bar 1999)"
+                table_dir.mkdir()
+                (table_dir / "Foo.vpx").write_bytes(b"x")
+                local = {"Info": {"VPSId": "local-id"}, "User": {"Rating": 3, "StartCount": 12}}
+                info_path = table_dir / "Foo (Bar 1999).info"
+                info_path.write_text(json.dumps(local))
+                zip_path = self._bundle(
+                    tmp, {"Info": {"VPSId": "foreign-id"}, "User": {"Rating": 5, "StartCount": 99}})
+                analysis = analyze_path(zip_path)
+                plan = build_import_plan(analysis, table_path=str(table_dir))
+                execute_import_plan(plan, zip_path)
+
+                data = json.loads(info_path.read_text())
+                self.assertEqual(data["Info"]["VPSId"], "local-id")     # association kept
+                self.assertEqual(data["User"]["Rating"], 3)             # history kept
+                self.assertEqual(data["User"]["StartCount"], 12)
+                backup = table_dir / "Foo (Bar 1999).info.bak"
+                self.assertTrue(backup.exists())
+                self.assertEqual(json.loads(backup.read_text()), local)
+
+
+class VpsHelperTests(unittest.TestCase):
+    def test_vps_folder_name_variants(self):
+        cases = [
+            ({"name": "Medieval Madness", "manufacturer": "Bally", "year": "1997"},
+             "Medieval Madness (Bally 1997)"),
+            ({"name": "Foo", "manufacturer": "Bally", "year": ""}, "Foo (Bally)"),
+            ({"name": "Foo", "year": "1997"}, "Foo (1997)"),
+            ({"name": "Foo"}, "Foo"),
+            ({"name": 'Bad<>:"/\\|?*Name', "manufacturer": "X", "year": "2000"},
+             "BadName (X 2000)"),
+        ]
+        for entry, expected in cases:
+            with self.subTest(entry=entry):
+                self.assertEqual(vps_folder_name(entry), expected)
+
+    def test_find_vps_entry(self):
+        rows = [{"id": "abc123", "name": "Foo"}, {"id": "def456", "name": "Bar"}]
+        with mock.patch("managerui.services.table_service.load_vpsdb", return_value=rows):
+            self.assertEqual(find_vps_entry("def456")["name"], "Bar")
+            self.assertIsNone(find_vps_entry("nope"))
+            self.assertIsNone(find_vps_entry(""))
+
+
+class ImportExecuteTests(unittest.TestCase):
+    def test_execute_places_assets_in_existing_table(self):
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        with mock.patch.object(asset_import_service, "refresh_table"):
+            with TemporaryDirectory() as tmp:
+                table_dir = Path(tmp) / "Foo (Bar 1999)"
+                table_dir.mkdir()
+                (table_dir / "Foo.vpx").write_bytes(b"old")
+                (table_dir / "Foo.directb2s").write_bytes(b"old-b2s")
+                zip_path = Path(tmp) / "assets.zip"
+                _make_zip(zip_path, [
+                    "Foo.vpx",
+                    "roms/mm.zip",
+                    "MyPup/screens.pup",
+                    "MyPup/s1/a.mp4",
+                    "mm.crz",
+                ])
+                analysis = analyze_path(zip_path)
+                plan = build_import_plan(analysis, table_path=str(table_dir), rom_name="mm_rom")
+                report = execute_import_plan(plan, zip_path)
+
+                self.assertTrue((table_dir / "pinmame" / "roms" / "mm.zip").exists())
+                self.assertTrue((table_dir / "pupvideos" / "s1" / "a.mp4").exists())
+                self.assertTrue((table_dir / "serum" / "mm_rom" / "mm.crz").exists())
+                self.assertIn("rom", report["imported"])
+
+    def test_execute_replace_vpx_restems_backglass(self):
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        with mock.patch.object(asset_import_service, "refresh_table"):
+            with TemporaryDirectory() as tmp:
+                table_dir = Path(tmp) / "Foo (Bar 1999)"
+                table_dir.mkdir()
+                (table_dir / "Old.vpx").write_bytes(b"old")
+                (table_dir / "Old.directb2s").write_bytes(b"b2s")
+                zip_path = Path(tmp) / "new.zip"
+                _make_zip(zip_path, ["New.vpx"])
+                analysis = analyze_path(zip_path)
+                plan = build_import_plan(analysis, table_path=str(table_dir))
+                execute_import_plan(plan, zip_path)
+
+                self.assertTrue((table_dir / "New.vpx").exists())
+                self.assertFalse((table_dir / "Old.vpx").exists())
+                # sibling backglass follows the new vpx stem
+                self.assertTrue((table_dir / "New.directb2s").exists())
+                self.assertFalse((table_dir / "Old.directb2s").exists())
+
+    def test_execute_new_bundle_creates_folder(self):
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        with mock.patch.object(asset_import_service, "refresh_table"):
+            with TemporaryDirectory() as tmp:
+                zip_path = Path(tmp) / "Medieval Madness.zip"
+                _make_zip(zip_path, ["Medieval Madness.vpx", "wheel.png"])
+                analysis = analyze_path(zip_path)
+                plan = build_import_plan(analysis, allow_new_table=True, tables_path=tmp)
+                report = execute_import_plan(plan, zip_path)
+                new_dir = Path(tmp) / "Medieval Madness"
+                self.assertTrue((new_dir / "Medieval Madness.vpx").exists())
+                self.assertTrue((new_dir / "medias" / "wheel.png").exists())
+                self.assertTrue(report["new_table"])
+
+    def test_execute_new_bundle_collision_raises(self):
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as tmp:
+            (Path(tmp) / "Medieval Madness").mkdir()
+            zip_path = Path(tmp) / "Medieval Madness.zip"
+            _make_zip(zip_path, ["Medieval Madness.vpx"])
+            analysis = analyze_path(zip_path)
+            plan = build_import_plan(analysis, allow_new_table=True, tables_path=tmp)
+            with self.assertRaises(ValueError):
+                execute_import_plan(plan, zip_path)
+
+
+class TraversalGuardTests(unittest.TestCase):
+    def test_safe_dest_rejects_traversal(self):
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            for bad in ["../evil.txt", "/abs/path", "a/../../b", "C:/win"]:
+                with self.subTest(path=bad):
+                    with self.assertRaises(ValueError):
+                        _safe_dest(base, bad)
+
+    def test_safe_dest_allows_nested(self):
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            dest = _safe_dest(base, "a/b/c.txt")
+            self.assertTrue(str(dest).startswith(str(base.resolve())))
+
+    def test_malicious_archive_member_blocked_on_extract(self):
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        import zipfile
+        with mock.patch.object(asset_import_service, "refresh_table"):
+            with TemporaryDirectory() as tmp:
+                table_dir = Path(tmp) / "Foo (Bar 1999)"
+                table_dir.mkdir()
+                (table_dir / "Foo.vpx").write_bytes(b"x")
+                zip_path = Path(tmp) / "evil.zip"
+                with zipfile.ZipFile(zip_path, "w") as archive:
+                    archive.writestr("Pack/screens.pup", b"x")
+                    archive.writestr("Pack/../../escape.mp4", b"x")
+                analysis = analyze_path(zip_path)
+                plan = build_import_plan(analysis, table_path=str(table_dir))
+                with self.assertRaises(ValueError):
+                    execute_import_plan(plan, zip_path)
+
+
+class UploadSessionServiceTests(unittest.TestCase):
+    def test_begin_store_finish_reassembles_tree(self):
+        import io
+        session = upload_session_service.begin_session()
+        try:
+            upload_session_service.store_file(session.upload_id, "a/b/c.txt", io.BytesIO(b"hello"))
+            upload_session_service.store_file(session.upload_id, "top.txt", io.BytesIO(b"hi"))
+            info = upload_session_service.finish_session(session.upload_id)
+            self.assertEqual(info["file_count"], 2)
+            directory = upload_session_service.get_session_dir(session.upload_id)
+            self.assertEqual((directory / "a" / "b" / "c.txt").read_bytes(), b"hello")
+        finally:
+            upload_session_service.cleanup_session(session.upload_id)
+
+    def test_unknown_session_raises(self):
+        with self.assertRaises(upload_session_service.UnknownSession):
+            upload_session_service.get_session_dir("does-not-exist")
+
+    def test_unsafe_relpath_rejected(self):
+        import io
+        session = upload_session_service.begin_session()
+        try:
+            for bad in ["../escape.txt", "/abs.txt", "a/../../b.txt"]:
+                with self.subTest(path=bad):
+                    with self.assertRaises(upload_session_service.UnsafePath):
+                        upload_session_service.store_file(session.upload_id, bad, io.BytesIO(b"x"))
+        finally:
+            upload_session_service.cleanup_session(session.upload_id)
+
+    def test_over_limit_rejected(self):
+        import io
+        session = upload_session_service.begin_session()
+        self.addCleanup(upload_session_service.cleanup_session, session.upload_id)
+        with mock.patch.object(upload_session_service, "MAX_TOTAL_BYTES", 4):
+            with self.assertRaises(upload_session_service.UploadTooLarge):
+                upload_session_service.store_file(session.upload_id, "big.bin", io.BytesIO(b"toolong"))
+
+    def test_cleanup_removes_directory(self):
+        session = upload_session_service.begin_session()
+        directory = upload_session_service.get_session_dir(session.upload_id)
+        self.assertTrue(directory.exists())
+        upload_session_service.cleanup_session(session.upload_id)
+        self.assertFalse(directory.exists())
+
+    def test_expired_sessions_are_swept(self):
+        session = upload_session_service.begin_session()
+        directory = upload_session_service.get_session_dir(session.upload_id)
+        # Force the session to look old, then a new begin() sweeps it.
+        with mock.patch.object(upload_session_service, "time") as fake_time:
+            fake_time.time.return_value = session.created + upload_session_service.SESSION_TTL_SECONDS + 1
+            other = upload_session_service.begin_session()
+        self.addCleanup(upload_session_service.cleanup_session, other.upload_id)
+        self.assertFalse(directory.exists())
+        with self.assertRaises(upload_session_service.UnknownSession):
+            upload_session_service.get_session_dir(session.upload_id)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This adds drag and drop importing to the manager UI. You can drop a single asset file, an archive (zip, rar, 7z), or a whole folder, and the app figures out what it is and imports it using the same conventions the existing upload buttons use. The buttons are all still there and unchanged — this sits alongside them.

There are four places to drop:

- The **Tables page** has a drop zone. Drop something with a `.vpx` in it and you get a new table; drop a bare asset with a single table row selected and it goes to that table.
- **Any table row** is itself a target — drop directly on a row and it imports to that table. The row under the cursor always wins over whatever's checked, and the confirm dialog says `Import to <table>` so a mis-aimed drop is caught before you commit.
- The **table detail dialog** has a drop zone for adding assets to the table you've got open.
- **Every media cell** in the Media view accepts a drop for that specific slot. Drop any image on a wheel cell and it's saved as the wheel; the slot decides the type and the canonical filename, so the file's own name doesn't matter.

The approach is modeled on how VPin Studio handles uploads: scan the archive listing without extracting it, detect what's inside by content rather than by which button was clicked, and route everything through one import engine. Detection covers table files, backglasses, table INIs, ROMs (flat rom-suffix archives or nested zips), serum and VNI color files, altsound (by its `altsound.csv`/`g-sound.csv` marker), PUP packs (marker files like `screens.pup`, with a folder-shape fallback), music folders, and media images/video/audio matched to their slots. Anything it doesn't recognize is listed in the dialog, expandable, so you can see exactly what got skipped.

New-table imports get a VPS association step in the dialog. It searches VPSdb from the vpx name (trimming author/version tails so "Medieval Madness VPW v2" still finds it), pre-selects the best match as a chip you can change or clear, and the folder name follows the VPS entry in the usual `Name (Manufacturer Year)` form. Files keep their original names — same as the Import Table dialog does today; only the folder is named from VPS.

If you drag a whole table folder from another machine and it includes the table's `.info`, that comes across too. Into a new folder it's adopted as-is. Onto a table you already have, it **merges** instead of overwriting: it fills in blank fields but never replaces your play history, keeps your existing VPS association unless the local table is unmatched, leaves the regenerable sections (`VPXFile`, `Medias`) to the rebuild, and writes a `.bak` first. A lone `.info` with no table next to it is deliberately left alone. The merge reuses the same "don't clobber unknown sections" spirit as #65.

Under the hood it's almost all new files: an asset registry, a listing-only analyzer with per-format backends, an import plan/execute engine, and a small upload-session service behind `POST /api/asset-upload/*` (begin/file/finish/abort, plus analyze/plan/import and a vps-search). The API is a plain `APIRouter` that `managerui.py` mounts, and it's driven entirely by the same functions the UI uses, so the whole thing is scriptable without the browser. The endpoints are unauthenticated, matching the existing `/api` routes. Uploads stream to temp files in 1 MiB chunks, sessions expire after an hour, and both the upload layer and archive extraction guard against path traversal. Touches to existing files are small — a `register_routes` call in `managerui.py`, wiring blocks in the three pages, and the RAR setting plumbing.

Two new dependencies: `py7zr` for 7z (pure Python, no external tool), and `rarfile` for rar. `rarfile` needs an `unrar`, `unar`, or `bsdtar` binary — it searches `PATH` and finds one automatically on most systems (macOS ships `bsdtar`). If none is found, a rar drop tells you up front, before the dialog, with platform-appropriate install guidance rather than a stack trace after the fact. And there's a new `rartoolpath` setting for pointing at the tool directly when it's installed somewhere off `PATH`, which happens on cabs launched from a frontend or service with a stripped environment. Blank means auto-detect.

A couple of things worth knowing for review. I haven't stress-tested multi-GB drops yet — the transport streams and never buffers a whole file, but I'd want to push a full-size PUP pack through before calling that proven. Solid 7z archives extract a member at a time, which will be slow for very large packs. And a new table imported without picking a VPS entry lands in Unmatched Tables like any hand-added table.

58 unit tests cover the detection rules, the traversal guards, plan routing, the `.info` merge policy, the RAR guidance, and the upload sessions; `python -m unittest discover tests` passes (three pre-existing macOS case-sensitivity failures aside). Tested live on macOS against real tables. Happy to split this up or rework any of it — it's a big change and I don't want to dump it on you all at once.
