### PR TITLE
Add backglass (.directb2s) detection and filter

### DIFF
--- a/common/table.py
+++ b/common/table.py
@@ -15,6 +15,7 @@ class Table:
     altColorExists: bool = False
     altSoundExists: bool = False
     vniExists: bool = False
+    b2sExists: bool = False
 
     BGImagePath: str | None = None
     DMDImagePath: str | None = None

--- a/common/table_repository.py
+++ b/common/table_repository.py
@@ -108,6 +108,7 @@ def table_to_row(table, collections_map: Optional[Dict[str, List[str]]] = None) 
         "detectflex": first_meta_value(meta, ("VPXFile", "detectflex")),
         "patch_applied": first_meta_value(meta, ("VPXFile", "patch_applied"), default=False),
         "table_path": table.fullPathTable,
+        "b2s_exists": bool(getattr(table, "b2sExists", False)),
         "pup_pack_exists": bool(getattr(table, "pupPackExists", False)),
         "serum_exists": bool(getattr(table, "altColorExists", False)),
         "vni_exists": bool(getattr(table, "vniExists", False)),

--- a/common/tableparser.py
+++ b/common/tableparser.py
@@ -77,6 +77,8 @@ class TableParser:
                 })
 
             # check for addons
+            if any(name.lower().endswith(".directb2s") for name in table_contents):
+                table.b2sExists = True
             if "pupvideos" in table_subdirs:
                 table.pupPackExists = True
             if "serum" in table_subdirs:

--- a/managerui/pages/table_detail_dialog.py
+++ b/managerui/pages/table_detail_dialog.py
@@ -393,6 +393,7 @@ def _render_table_dialog(row_data: dict, on_close: Optional[Callable[[], None]] 
 
                 # Detected Addons row
                 addon_fields = [
+                    ('b2s_exists', 'B2S', None, None),
                     ('pup_pack_exists', 'PUP Pack', 'video_library', 'purple'),
                     ('serum_exists', 'Serum', 'palette', 'orange'),
                     ('vni_exists', 'VNI', 'palette', 'cyan'),
@@ -407,7 +408,8 @@ def _render_table_dialog(row_data: dict, on_close: Optional[Callable[[], None]] 
                             exists = row_data.get(key, False)
                             if exists:
                                 with ui.row().classes('items-center gap-1'):
-                                    ui.icon(icon, size='16px').classes(f'text-{color}-400')
+                                    if icon:
+                                        ui.icon(icon, size='16px').classes(f'text-{color}-400')
                                     ui.badge(label, color='positive').props('rounded')
                             else:
                                 ui.badge(label, color='grey').props('rounded outline')

--- a/managerui/pages/tables.py
+++ b/managerui/pages/tables.py
@@ -610,6 +610,7 @@ def render_panel(tab=None):
             'theme': 'All',
             'table_type': 'All',
             'has_pup_pack': False,
+            'has_b2s': False,
         }
 
         def get_filter_options_from_cache():
@@ -621,6 +622,8 @@ def render_panel(tab=None):
             extra_predicates = []
             if filter_state['has_pup_pack']:
                 extra_predicates.append(lambda row: row.get('pup_pack_exists', False))
+            if filter_state['has_b2s']:
+                extra_predicates.append(lambda row: row.get('b2s_exists', False))
             return apply_table_filters(
                 _tables_cache() or [],
                 filter_state,
@@ -665,6 +668,10 @@ def render_panel(tab=None):
             filter_state['has_pup_pack'] = e.value or False
             update_table_display()
 
+        def on_b2s_change(e: events.ValueChangeEventArguments):
+            filter_state['has_b2s'] = e.value or False
+            update_table_display()
+
         def clear_filters():
             filter_state['search'] = ''
             filter_state['manufacturer'] = 'All'
@@ -672,12 +679,14 @@ def render_panel(tab=None):
             filter_state['theme'] = 'All'
             filter_state['table_type'] = 'All'
             filter_state['has_pup_pack'] = False
+            filter_state['has_b2s'] = False
             search_input.value = ''
             manufacturer_select.value = 'All'
             year_select.value = 'All'
             theme_select.value = 'All'
             table_type_select.value = 'All'
             pup_pack_checkbox.value = False
+            b2s_checkbox.value = False
             table._props['pagination']['page'] = 1
             update_table_display()
 
@@ -735,6 +744,10 @@ def render_panel(tab=None):
                 # PUP Pack checkbox
                 pup_pack_checkbox = ui.checkbox('PUP Pack', value=False).style('color: var(--ink);')
                 pup_pack_checkbox.on_value_change(on_pup_pack_change)
+
+                # Backglass (B2S) checkbox
+                b2s_checkbox = ui.checkbox('Backglass (B2S)', value=False).style('color: var(--ink);')
+                b2s_checkbox.on_value_change(on_b2s_change)
 
                 # Clear filters button
                 ui.button(icon='clear_all', on_click=clear_filters).props('flat round').tooltip('Clear all filters')

--- a/tests/test_common_architecture.py
+++ b/tests/test_common_architecture.py
@@ -13,6 +13,7 @@ from common.media_paths import apply_media_paths, media_filename_map, table_medi
 from common.metadata_service import claim_media_for_table
 from common.standalonescripts import StandaloneScripts
 from common.table_metadata import table_themes, table_title, table_type
+from common.table_repository import table_to_row
 from common.tableparser import TableParser
 from common.theme_installer import ThemeInstallStore
 from common.vpsdb_cache import VPSDatabaseCache
@@ -237,6 +238,29 @@ class TestCommonArchitecture(unittest.TestCase):
 
         self.assertEqual(messages, ["hello"])
         self.assertEqual(progress, [(1, 2, "half")])
+
+    def test_tableparser_detects_directb2s_case_insensitively(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with_b2s = root / "With B2S (Bally 1990)"
+            with_b2s.mkdir()
+            (with_b2s / "With B2S (Bally 1990).vpx").write_text("")
+            (with_b2s / "With B2S (Bally 1990).DirectB2S").write_text("")
+
+            without_b2s = root / "No B2S (Bally 1991)"
+            without_b2s.mkdir()
+            (without_b2s / "No B2S (Bally 1991).vpx").write_text("")
+
+            parser = TableParser(root)
+            parser.loadTables()
+            by_name = {t.tableDirName: t for t in parser.getAllTables()}
+
+            self.assertTrue(by_name["With B2S (Bally 1990)"].b2sExists)
+            self.assertFalse(by_name["No B2S (Bally 1991)"].b2sExists)
+
+            # table_to_row mirrors the flag for the UI
+            self.assertTrue(table_to_row(by_name["With B2S (Bally 1990)"])["b2s_exists"])
+            self.assertFalse(table_to_row(by_name["No B2S (Bally 1991)"])["b2s_exists"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Surfaces whether a table has a backglass. The scan now flags any `.directb2s` in the table folder, shown as a chip in the detail dialog and a filter checkbox on the Tables page (mirrors PUP Pack).

Not sent to themes for now, same as `vniExists`.