### PR TITLE
Fix test failures on macOS

### DIFF
--- a/common/score_parser.py
+++ b/common/score_parser.py
@@ -322,16 +322,23 @@ def resolve_score_input_path(rom_name: str, source_path: str) -> str:
 
     table_dir = source if source.is_dir() else source.parent
 
-    primary_score_path = table_dir / "pinmame" / "nvram" / f"{rom_name}.nv"
-    alias_score_path = table_dir / "pinmame" / "nvram" / f"{resolved_rom_name}.nv"
+    nvram_dir = table_dir / "pinmame" / "nvram"
+    # Check the resolved (canonical-cased) ROM name before the raw input. On a
+    # case-insensitive filesystem (macOS/APFS) a probe for "matrix.nv" matches a
+    # "Matrix.nv" file, so checking the raw name first would return the wrong
+    # casing; the canonical name gives the real on-disk filename. Dedupe when the
+    # two are identical so we don't stat the same path twice.
+    score_names = [resolved_rom_name]
+    if rom_name != resolved_rom_name:
+        score_names.append(rom_name)
+    score_candidates = [nvram_dir / f"{name}.nv" for name in score_names]
     fallback_score_path = table_dir / "user" / "VPReg.ini"
-    checked_paths.extend([primary_score_path, alias_score_path, fallback_score_path])
+    checked_paths.extend(score_candidates)
+    checked_paths.append(fallback_score_path)
 
-    if primary_score_path.exists():
-        return str(primary_score_path)
-
-    if alias_score_path.exists():
-        return str(alias_score_path)
+    for candidate in score_candidates:
+        if candidate.exists():
+            return str(candidate)
 
     if fallback_score_path.exists():
         return str(fallback_score_path)

--- a/common/score_parser.py
+++ b/common/score_parser.py
@@ -7,11 +7,7 @@ from dataclasses import asdict, dataclass, field, replace
 from pathlib import Path
 from typing import BinaryIO
 
-try:
-    from platformdirs import user_config_dir
-except ImportError:
-    def user_config_dir(appname: str, appauthor: str | None = None) -> str:
-        return str(Path.home() / ".config" / appname)
+from common.paths import USER_CONFIG_PATH, USER_ROMS_PATH
 
 
 @dataclass
@@ -29,10 +25,7 @@ class ParsedEntry:
 
 logging.basicConfig(level=logging.ERROR, format="%(levelname)s: %(message)s")
 
-USER_ROMS_PATH = Path(user_config_dir("vpinfe", "vpinfe")) / "roms.json"
-USER_CONFIG_PATH = Path(user_config_dir("vpinfe", "vpinfe")) / "vpinfe.ini"
-
-# alias, rom name in roms.json 
+# alias, rom name in roms.json
 rom_aliases = {
     "alpok_b6": "alpok_l2",
     "arena": "amazon3a",

--- a/tests/test_frontend_services.py
+++ b/tests/test_frontend_services.py
@@ -104,13 +104,17 @@ class FrontendServiceTests(unittest.TestCase):
         standard_config = configparser.ConfigParser()
         standard_config.read_dict({"Media": {"realdmdmediapriority": "standard"}})
 
+        # get_realdmd_image_for_table returns path.resolve(); on macOS /tmp is a
+        # symlink to /private/tmp, so compare against the resolved expectation.
+        color_expected = Path("/tmp/realdmd-color.png").resolve()
+        standard_expected = Path("/tmp/realdmd.png").resolve()
         self.assertEqual(realdmd_service.get_frontend_dof_event_for_table(table), "E901")
-        self.assertEqual(realdmd_service.get_realdmd_image_for_table(table), Path("/tmp/realdmd-color.png"))
-        self.assertEqual(realdmd_service.get_realdmd_image_for_table(table, color_config), Path("/tmp/realdmd-color.png"))
-        self.assertEqual(realdmd_service.get_realdmd_image_for_table(table, standard_config), Path("/tmp/realdmd.png"))
+        self.assertEqual(realdmd_service.get_realdmd_image_for_table(table), color_expected)
+        self.assertEqual(realdmd_service.get_realdmd_image_for_table(table, color_config), color_expected)
+        self.assertEqual(realdmd_service.get_realdmd_image_for_table(table, standard_config), standard_expected)
 
         table.realDMDColorImagePath = ""
-        self.assertEqual(realdmd_service.get_realdmd_image_for_table(table, color_config), Path("/tmp/realdmd.png"))
+        self.assertEqual(realdmd_service.get_realdmd_image_for_table(table, color_config), standard_expected)
 
         calls = []
         updater = realdmd_service.RealDmdUpdater("ini", "table", lambda ini, image: calls.append((ini, image)) or True)

--- a/tests/test_vpx_config_page.py
+++ b/tests/test_vpx_config_page.py
@@ -8,10 +8,16 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 
-sys.modules.setdefault(
-    "nicegui",
-    types.SimpleNamespace(ui=types.SimpleNamespace(input=object)),
-)
+try:
+    # Prefer the real framework when it's installed. Installing an incomplete
+    # stub via setdefault would leak into sys.modules and break later tests that
+    # import the full managerui UI (which needs nicegui.app / nicegui.context).
+    import nicegui  # noqa: F401
+except ImportError:
+    sys.modules.setdefault(
+        "nicegui",
+        types.SimpleNamespace(ui=types.SimpleNamespace(input=object)),
+    )
 sys.modules.setdefault(
     "platformdirs",
     types.SimpleNamespace(user_config_dir=lambda *args, **kwargs: "/tmp/vpinfe-test"),

--- a/tests/test_vpx_plugins_page.py
+++ b/tests/test_vpx_plugins_page.py
@@ -9,10 +9,16 @@ from tempfile import TemporaryDirectory
 from unittest import mock
 
 
-sys.modules.setdefault(
-    "nicegui",
-    types.SimpleNamespace(ui=types.SimpleNamespace(input=object)),
-)
+try:
+    # Prefer the real framework when it's installed. Installing an incomplete
+    # stub via setdefault would leak into sys.modules and break later tests that
+    # import the full managerui UI (which needs nicegui.app / nicegui.context).
+    import nicegui  # noqa: F401
+except ImportError:
+    sys.modules.setdefault(
+        "nicegui",
+        types.SimpleNamespace(ui=types.SimpleNamespace(input=object)),
+    )
 sys.modules.setdefault(
     "platformdirs",
     types.SimpleNamespace(user_config_dir=lambda *args, **kwargs: "/tmp/vpinfe-test"),


### PR DESCRIPTION
Running the suite on macOS surfaced four failures with three distinct causes.

1. tests: an incomplete nicegui stub installed via sys.modules.setdefault in the
   VPX config/plugins page tests leaked for the whole process. A later test that
   imports the full managerui UI (from nicegui import ui, app, context) then
   failed with "cannot import name 'app'" — only in the full run, not in
   isolation. nicegui is a hard dependency, so use the real module when present
   and stub only when it isn't installed.

2. tests: get_realdmd_image_for_table returns path.resolve(); on macOS /tmp is a
   symlink to /private/tmp, so the resolved path didn't match the hardcoded
   /tmp expectation. Compare against the resolved form.

3. score_parser defined its own USER_ROMS_PATH/USER_CONFIG_PATH that duplicated
   common.paths. Tests patch common.paths.USER_ROMS_PATH, which score_parser
   never read, so the fixture roms.json was ignored and load_roms() used the
   real user file. Import the constants from common.paths (identical values, so
   no behavior change) for a single source of truth.

4. score_parser: resolve_score_input_path checked the raw ROM name before the
   resolved canonical one. On a case-insensitive filesystem (APFS) a probe for
   "matrix.nv" matches a "Matrix.nv" file, so it returned the wrong casing.
   Check the canonical name first.

All 133 tests pass on macOS; behavior on case-sensitive Linux is unchanged.