### PR TITLE
Add a setting to reopen the frontend on the last table you launched

### DIFF
--- a/common/config_access.py
+++ b/common/config_access.py
@@ -59,6 +59,7 @@ class SettingsConfig:
     disable_default_chrome_options: bool = False
     cab_mode: bool = False
     hide_quit_button: bool = False
+    restore_last_table: bool = True
 
     @classmethod
     def from_config(cls, source: Any) -> "SettingsConfig":
@@ -82,6 +83,7 @@ class SettingsConfig:
             disable_default_chrome_options=cfg_bool(source, "Settings", "disabledefaultchromeoptions", False),
             cab_mode=cfg_bool(source, "Settings", "cabmode", False),
             hide_quit_button=cfg_bool(source, "Settings", "MMhideQuitButton", False),
+            restore_last_table=cfg_bool(source, "Settings", "restorelasttable", True),
         )
 
 

--- a/common/iniconfig.py
+++ b/common/iniconfig.py
@@ -46,6 +46,7 @@ class IniConfig:
 				'chromeoptionsexclude': '',
 				'disabledefaultchromeoptions': 'false',
 				'MMhideQuitButton': 'false',
+				'restorelasttable': 'true',
 				},
 			'Input': {
 				'joyleft': '',
@@ -89,6 +90,7 @@ class IniConfig:
 					'realdmdmediapriority': 'color',
 					},
 			'VPSdb': {'last': ''},
+			'State': {'lasttable': ''},
 			'pinmame-score-parser': {
 				'romsupdatesha': '',
 				},

--- a/docs/technical_details.md
+++ b/docs/technical_details.md
@@ -19,6 +19,7 @@ VPinFE uses a platform-specific configuration directory to store its settings. O
 | tablerootdir      | The root folder where all your tables are located.  e.g /vpx/tables/      |
 | startup_collection| Set the collection VPinFE starts up with.  Case sensitive, match collection name. |
 | splashscreen      | Enable or disable the splash screen at startup. Default is `false`. |
+| restorelasttable  | Open the wheel on the last table you launched instead of the first. Default is `true`. |
 
 ### [Input]
 | Key               | Description |
@@ -38,6 +39,12 @@ VPinFE uses a platform-specific configuration directory to store its settings. O
 | Key               | Description |
 | ----------------- | ------------------------------------------------------------------------- |
 | last              | Rev of VPSDB that was last pulled.                                        |
+
+### [State]
+Internal state written by VPinFE, not shown in the Manager UI.
+| Key               | Description |
+| ----------------- | ------------------------------------------------------------------------- |
+| lasttable         | Path of the last table you launched. Used by `restorelasttable` to reopen on that table. |
 
 ### [Media]
 | Key               | Description |

--- a/frontend/api.py
+++ b/frontend/api.py
@@ -25,7 +25,7 @@ from common.vpinplay_runtime import (
     clear_alternate_profile,
     get_alternate_profile_state,
 )
-from frontend import config_api, input_api, launch_service, metadata_build_service, realdmd_service, table_state, theme_api
+from frontend import config_api, input_api, last_table, launch_service, metadata_build_service, realdmd_service, table_state, theme_api
 
 
 logger = logging.getLogger("vpinfe.frontend.api")
@@ -45,6 +45,7 @@ API_ALLOWED_METHODS = {
     'shutdown_system',
     'get_monitors',
     'get_tables',
+    'get_initial_table_index',
     'get_collections',
     'get_collections_metadata',
     'get_collection_image_url',
@@ -184,6 +185,11 @@ class API:
             self.filteredTables = self.allTables
         self.jsTableDictData = table_state.tables_json(self.filteredTables)
         return self.jsTableDictData
+
+    def get_initial_table_index(self):
+        # Position the wheel on the last-launched table at startup. Resolved
+        # against the current (possibly filtered) view; 0 when disabled or unfound.
+        return last_table.resolve_last_table_index(self._iniConfig, self.filteredTables)
 
 
     def get_collections(self):

--- a/frontend/last_table.py
+++ b/frontend/last_table.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import logging
+
+from common.config_access import SettingsConfig, cfg_get
+
+
+logger = logging.getLogger("vpinfe.frontend.last_table")
+
+# Internal state, not a user-facing setting. Kept in its own section so the
+# Manager UI (which renders every key in a shown section) never surfaces it.
+STATE_SECTION = "State"
+STATE_KEY = "lasttable"
+
+
+def table_identity(table) -> str:
+    """Stable id for a table, preferring its absolute path over its dir name.
+
+    Used both to save the last-launched table and to resolve it back to an
+    index, so it must be computed the same way in both directions.
+    """
+    return str(getattr(table, "fullPathTable", "") or getattr(table, "tableDirName", "") or "")
+
+
+def save_last_table(iniConfig, table) -> None:
+    """Persist `table` as the last-launched table when the feature is enabled."""
+    if not SettingsConfig.from_config(iniConfig).restore_last_table:
+        return
+    identity = table_identity(table)
+    if not identity:
+        return
+    parser = iniConfig.config
+    if not parser.has_section(STATE_SECTION):
+        parser.add_section(STATE_SECTION)
+    if parser.get(STATE_SECTION, STATE_KEY, fallback="") == identity:
+        return  # unchanged; skip the disk write
+    parser.set(STATE_SECTION, STATE_KEY, identity)
+    try:
+        iniConfig.save()
+    except Exception:
+        logger.exception("Could not persist last table selection")
+
+
+def resolve_last_table_index(iniConfig, tables) -> int:
+    """Return the index of the saved last table within `tables`, else 0.
+
+    Returns 0 when the feature is off, nothing is saved, or the saved table
+    isn't in the current view (e.g. filtered out by a startup collection).
+    """
+    if not SettingsConfig.from_config(iniConfig).restore_last_table:
+        return 0
+    saved = cfg_get(iniConfig, STATE_SECTION, STATE_KEY, "").strip()
+    if not saved:
+        return 0
+    for index, table in enumerate(tables):
+        if table_identity(table) == saved:
+            return index
+    return 0

--- a/frontend/launch_service.py
+++ b/frontend/launch_service.py
@@ -19,6 +19,7 @@ from common.vpinplay_runtime import (
     set_table_score,
 )
 from common.vpinplay_service import sync_single_table_meta
+from frontend.last_table import save_last_table
 
 
 logger = logging.getLogger("vpinfe.frontend.launch_service")
@@ -100,6 +101,7 @@ def launch_table(
 
     delete_vpinball_log_on_start_if_configured(settings)
     table_play_service.track_table_play(table)
+    save_last_table(api._iniConfig, table)
     api.send_event_all_windows_incself({"type": "TableLaunching"})
 
     stop_dof_service()

--- a/managerui/config_fields.py
+++ b/managerui/config_fields.py
@@ -16,6 +16,7 @@ INPUT_MAPPING_ACTION_ORDER = [
 
 CHECKBOX_FIELDS = {
     ("Settings", "autoupdatemediaonstartup"),
+    ("Settings", "restorelasttable"),
     ("Settings", "splashscreen"),
     ("Settings", "muteaudio"),
     ("Settings", "mmhidequitbutton"),

--- a/managerui/pages/vpinfe_config.py
+++ b/managerui/pages/vpinfe_config.py
@@ -28,6 +28,7 @@ IGNORED_SECTIONS = {
     'VPSdb',
     'pinmame-score-parser',
     'vpinplay',
+    'State',
 }
 
 # Icons for each section (fallback to 'settings' if not defined)
@@ -67,6 +68,7 @@ FRIENDLY_NAMES = {
     'tablerootdir': 'Tables Directory',
     'startup_collection': 'Startup Collection',
     'autoupdatemediaonstartup': 'Auto Update Media On Startup',
+    'restorelasttable': 'Restore Last Table',
     'splashscreen': 'Enable splashscreen',
     'muteaudio': 'Mute Frontend Audio',
     'chromeoptions': 'Additional Chrome Options',

--- a/readme.md
+++ b/readme.md
@@ -220,6 +220,7 @@ Core startup and launch behavior:
 - **Active Theme**: currently selected frontend theme
 - **Startup Collection**: collection opened when VPinFE starts
 - **Auto Update Media On Startup**: enables startup media refresh behavior
+- **Restore Last Table**: opens the wheel on the last table you launched instead of the first; on by default, saved as `Settings.restorelasttable`
 - **Enable splashscreen**: shows the frontend splash screen during startup
 - **Mute Frontend Audio**: mutes frontend audio playback
 - **Hide Quit from MainMenu**: hides the **Quit** item from the frontend main menu; saved as `Settings.MMhideQuitButton` in `vpinfe.ini`

--- a/tests/test_iniconfig.py
+++ b/tests/test_iniconfig.py
@@ -100,6 +100,24 @@ class TestIniConfig(unittest.TestCase):
             self.assertTrue(config.config.has_section("Settings"))
             self.assertEqual(config.config.get("Settings", "vpxlogdeleteonstart"), "false")
 
+    def test_restore_last_table_defaults_on(self) -> None:
+        with TemporaryDirectory() as tmp:
+            ini_path = Path(tmp) / "vpinfe.ini"
+
+            config = IniConfig(str(ini_path))
+
+            self.assertTrue(config.config.has_section("Settings"))
+            self.assertEqual(config.config.get("Settings", "restorelasttable"), "true")
+
+    def test_state_section_lasttable_defaults_empty(self) -> None:
+        with TemporaryDirectory() as tmp:
+            ini_path = Path(tmp) / "vpinfe.ini"
+
+            config = IniConfig(str(ini_path))
+
+            self.assertTrue(config.config.has_section("State"))
+            self.assertEqual(config.config.get("State", "lasttable"), "")
+
     def test_existing_splashscreen_setting_is_preserved(self) -> None:
         with TemporaryDirectory() as tmp:
             ini_path = Path(tmp) / "vpinfe.ini"

--- a/tests/test_last_table.py
+++ b/tests/test_last_table.py
@@ -1,0 +1,91 @@
+import unittest
+from dataclasses import dataclass
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from common.iniconfig import IniConfig
+from frontend import last_table
+
+
+@dataclass
+class FakeTable:
+    fullPathTable: str = ""
+    tableDirName: str = ""
+
+
+def _config(tmp: str) -> IniConfig:
+    return IniConfig(str(Path(tmp) / "vpinfe.ini"))
+
+
+class TestLastTable(unittest.TestCase):
+    def test_save_then_resolve_round_trips(self) -> None:
+        with TemporaryDirectory() as tmp:
+            config = _config(tmp)
+            tables = [
+                FakeTable(fullPathTable="/tables/AAA", tableDirName="AAA"),
+                FakeTable(fullPathTable="/tables/BBB", tableDirName="BBB"),
+                FakeTable(fullPathTable="/tables/CCC", tableDirName="CCC"),
+            ]
+
+            last_table.save_last_table(config, tables[2])
+
+            self.assertEqual(config.config.get("State", "lasttable"), "/tables/CCC")
+            self.assertEqual(last_table.resolve_last_table_index(config, tables), 2)
+
+    def test_resolve_survives_reordering(self) -> None:
+        with TemporaryDirectory() as tmp:
+            config = _config(tmp)
+            table = FakeTable(fullPathTable="/tables/BBB", tableDirName="BBB")
+            last_table.save_last_table(config, table)
+
+            reordered = [
+                FakeTable(fullPathTable="/tables/CCC", tableDirName="CCC"),
+                FakeTable(fullPathTable="/tables/BBB", tableDirName="BBB"),
+                FakeTable(fullPathTable="/tables/AAA", tableDirName="AAA"),
+            ]
+            self.assertEqual(last_table.resolve_last_table_index(config, reordered), 1)
+
+    def test_resolve_returns_zero_when_not_found(self) -> None:
+        with TemporaryDirectory() as tmp:
+            config = _config(tmp)
+            config.config.set("State", "lasttable", "/tables/GONE")
+
+            tables = [FakeTable(fullPathTable="/tables/AAA", tableDirName="AAA")]
+            self.assertEqual(last_table.resolve_last_table_index(config, tables), 0)
+
+    def test_resolve_returns_zero_when_nothing_saved(self) -> None:
+        with TemporaryDirectory() as tmp:
+            config = _config(tmp)
+            tables = [FakeTable(fullPathTable="/tables/AAA", tableDirName="AAA")]
+            self.assertEqual(last_table.resolve_last_table_index(config, tables), 0)
+
+    def test_disabled_skips_save_and_resolve(self) -> None:
+        with TemporaryDirectory() as tmp:
+            config = _config(tmp)
+            config.config.set("Settings", "restorelasttable", "false")
+
+            tables = [
+                FakeTable(fullPathTable="/tables/AAA", tableDirName="AAA"),
+                FakeTable(fullPathTable="/tables/BBB", tableDirName="BBB"),
+            ]
+            last_table.save_last_table(config, tables[1])
+
+            # Nothing persisted, and resolution is short-circuited to 0.
+            self.assertEqual(config.config.get("State", "lasttable"), "")
+            self.assertEqual(last_table.resolve_last_table_index(config, tables), 0)
+
+    def test_falls_back_to_dir_name_when_path_missing(self) -> None:
+        with TemporaryDirectory() as tmp:
+            config = _config(tmp)
+            table = FakeTable(fullPathTable="", tableDirName="OnlyDirName")
+            last_table.save_last_table(config, table)
+
+            self.assertEqual(config.config.get("State", "lasttable"), "OnlyDirName")
+            self.assertEqual(
+                last_table.resolve_last_table_index(config, [FakeTable(tableDirName="Other"), table]),
+                1,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/common/vpinfe-core.js
+++ b/web/common/vpinfe-core.js
@@ -93,6 +93,7 @@ class VPinFECore {
     this.themeConfig = {};
     this.mediaPriorities = Object.assign({}, DEFAULT_MEDIA_PRIORITIES);
     this._currentTableIndex = 0;
+    this._initialTableRestored = false;
     this._coreAudioEnabled = true;
     this._audioMuted = false;
     this._audio = Object.assign(new Audio(), { loop: true });
@@ -414,11 +415,31 @@ class VPinFECore {
       const maxIndex = Math.max(0, this.tableData.length - 1);
       if (this._currentTableIndex > maxIndex) this._currentTableIndex = maxIndex;
       if (this.tableData.length > 0) {
+        if (!this._initialTableRestored) {
+          this._initialTableRestored = true;
+          await this.#restoreInitialTable();
+        }
         this.getVPinPlayRating(this._currentTableIndex).catch(() => {});
         this.#updateFrontendDofForCurrentTable().catch(() => {});
       } else {
         this._lastFrontendDofIndex = null;
       }
+    }
+  }
+
+  // On first table-data load, ask the backend for the last-launched table's
+  // index and, if it isn't already first, move the wheel there. Sending a
+  // TableIndexUpdate (inc self) drives the theme through the same path its own
+  // input uses, so no theme changes are needed to honor the restored position.
+  async #restoreInitialTable() {
+    try {
+      const index = await this.call("get_initial_table_index");
+      if (typeof index === "number" && index > 0 && index < this.tableData.length) {
+        this._currentTableIndex = index;
+        this.sendMessageToAllWindowsIncSelf({ type: "TableIndexUpdate", index });
+      }
+    } catch (e) {
+      this.call("console_out", `restoreInitialTable failed: ${e.message}`);
     }
   }
 


### PR DESCRIPTION
The frontend always starts on the first table. This adds an opt-out setting to reopen on the last table you launched.

New `[Settings] restorelasttable` (default `true`): launching a table records it, and the next startup opens the wheel on that table. The table is stored by path in a new internal `[State] lasttable` key, so the selection survives re-sorting and filtering — resolving by path instead of a raw index is what keeps it stable. It falls back to the first table when the setting is off, nothing is saved, or the saved table isn't in the current view (e.g. filtered out by a startup collection).

At startup the table window asks the backend for the saved table's index and fires a `TableIndexUpdate`. Themes already move the wheel on that event, so this works with Revolution and any other theme without theme changes. Save happens on launch only, so it remembers the last table you played, not wherever the wheel was sitting.

In the Manager UI it shows as a "Restore Last Table" checkbox. The internal `lasttable` value stays hidden — its `[State]` section is in the ignored list, same as `[VPSdb]`.

Added unit tests for the ini defaults/backfill and the save/resolve logic (found, not-found, disabled, survives reordering, dir-name fallback); full suite passes. Docs updated in `technical_details.md` and the readme.
