### PR TITLE
Always fire TableLaunchComplete so a failed launch can't brick frontend input

### DIFF
--- a/frontend/launch_service.py
+++ b/frontend/launch_service.py
@@ -104,76 +104,84 @@ def launch_table(
     save_last_table(api._iniConfig, table)
     api.send_event_all_windows_incself({"type": "TableLaunching"})
 
-    stop_dof_service()
-    stop_libdmdutil_service(clear=False)
-    launch_started_at = None
-    launch_profile = None
+    # TableLaunching suppresses frontend input; TableLaunchComplete restores it.
+    # Once we've fired Launching we must fire Complete no matter what, or a
+    # failure anywhere below (bad launch command, a raising popen, post-launch
+    # bookkeeping) leaves the frontend with input suppressed for the life of the
+    # process. Wrap the whole body so Complete always goes out, then let any real
+    # failure keep propagating so it still gets logged.
     try:
-        global_ini_override = settings.global_ini_override
-        tableini_override = resolve_launch_tableini_override(
-            vpx,
-            settings.global_table_ini_override_enabled,
-            settings.global_table_ini_override_mask,
-        )
-        plugin_profile_override = resolve_launch_plugin_profile(
-            get_plugin_profile_from_meta(table.metaConfig)
-        )
-        cmd = build_vpx_launch_command(
-            launcher_path=str(vpxbin_path),
-            vpx_table_path=vpx,
-            global_ini_override=global_ini_override,
-            tableini_override=tableini_override,
-            plugin_profile_override=plugin_profile_override,
-        )
-        logger.info("Launching: %s", cmd)
-        launch_env = os.environ.copy()
-        launch_env.update(parse_launch_env_overrides(settings.vpx_launch_env))
-        
-        # Prevent usage of bundled libaries on Linux
-        # PyInstaller bundles libaries which might be incompatible with the local files.
-        system = platform.system()
-        if system == "Linux" and getattr(sys, "frozen", False): 
-            lp_key = 'LD_LIBRARY_PATH'
-            lp_orig = launch_env.get(lp_key + '_ORIG')
-            if lp_orig is not None:
-                launch_env[lp_key] = lp_orig  # restore the original, unmodified value
+        stop_dof_service()
+        stop_libdmdutil_service(clear=False)
+        launch_started_at = None
+        launch_profile = None
+        try:
+            global_ini_override = settings.global_ini_override
+            tableini_override = resolve_launch_tableini_override(
+                vpx,
+                settings.global_table_ini_override_enabled,
+                settings.global_table_ini_override_mask,
+            )
+            plugin_profile_override = resolve_launch_plugin_profile(
+                get_plugin_profile_from_meta(table.metaConfig)
+            )
+            cmd = build_vpx_launch_command(
+                launcher_path=str(vpxbin_path),
+                vpx_table_path=vpx,
+                global_ini_override=global_ini_override,
+                tableini_override=tableini_override,
+                plugin_profile_override=plugin_profile_override,
+            )
+            logger.info("Launching: %s", cmd)
+            launch_env = os.environ.copy()
+            launch_env.update(parse_launch_env_overrides(settings.vpx_launch_env))
 
-        process = popen(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            stdin=subprocess.DEVNULL,
-            text=True,
-            env=launch_env,
-        )
-        launch_started_at = time.time()
-        launch_profile = get_active_profile()
-        if launch_profile is not None:
-            record_table_start(str(table.fullPathTable or table.tableDirName or ""))
-        else:
-            table_play_service.increment_start_count(table)
+            # Prevent usage of bundled libaries on Linux
+            # PyInstaller bundles libaries which might be incompatible with the local files.
+            system = platform.system()
+            if system == "Linux" and getattr(sys, "frozen", False):
+                lp_key = 'LD_LIBRARY_PATH'
+                lp_orig = launch_env.get(lp_key + '_ORIG')
+                if lp_orig is not None:
+                    launch_env[lp_key] = lp_orig  # restore the original, unmodified value
 
-        startup_detected = False
-        for line in process.stdout:
-            if not startup_detected and "Startup done" in line:
-                startup_detected = True
-                api.send_event_all_windows_incself({"type": "TableRunning"})
-                logger.info("table running")
+            process = popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                stdin=subprocess.DEVNULL,
+                text=True,
+                env=launch_env,
+            )
+            launch_started_at = time.time()
+            launch_profile = get_active_profile()
+            if launch_profile is not None:
+                record_table_start(str(table.fullPathTable or table.tableDirName or ""))
+            else:
+                table_play_service.increment_start_count(table)
 
-        process.wait()
+            startup_detected = False
+            for line in process.stdout:
+                if not startup_detected and "Startup done" in line:
+                    startup_detected = True
+                    api.send_event_all_windows_incself({"type": "TableRunning"})
+                    logger.info("table running")
+
+            process.wait()
+        finally:
+            start_dof_service_if_enabled(api._iniConfig)
+
+        if launch_started_at is not None:
+            elapsed_seconds = max(0.0, time.time() - launch_started_at)
+            if launch_profile is not None:
+                _submit_alternate_vpinplay_result(api, table, elapsed_seconds, launch_profile)
+            else:
+                table_play_service.add_runtime_minutes(table, elapsed_seconds)
+                table_play_service.update_score_from_nvram(table)
+
+        if sys.platform == "darwin" and api.frontend_browser:
+            api.frontend_browser.activate_all_mac()
+
+        table_play_service.delete_nvram_if_configured(table)
     finally:
-        start_dof_service_if_enabled(api._iniConfig)
-
-    if launch_started_at is not None:
-        elapsed_seconds = max(0.0, time.time() - launch_started_at)
-        if launch_profile is not None:
-            _submit_alternate_vpinplay_result(api, table, elapsed_seconds, launch_profile)
-        else:
-            table_play_service.add_runtime_minutes(table, elapsed_seconds)
-            table_play_service.update_score_from_nvram(table)
-
-    if sys.platform == "darwin" and api.frontend_browser:
-        api.frontend_browser.activate_all_mac()
-
-    table_play_service.delete_nvram_if_configured(table)
-    api.send_event_all_windows_incself({"type": "TableLaunchComplete"})
+        api.send_event_all_windows_incself({"type": "TableLaunchComplete"})

--- a/tests/test_launch_service.py
+++ b/tests/test_launch_service.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import types
+import unittest
+from unittest import mock
+
+from frontend import launch_service
+
+
+class _FakePopen:
+    """Minimal stand-in for subprocess.Popen good enough for launch_table."""
+
+    def __init__(self, lines=()):
+        self.stdout = list(lines)
+        self.waited = False
+
+    def wait(self):
+        self.waited = True
+        return 0
+
+
+def _make_api(events):
+    table = types.SimpleNamespace(
+        fullPathVPXfile="/tables/example.vpx",
+        fullPathTable="/tables/example",
+        tableDirName="Example",
+        metaConfig={},
+    )
+    return types.SimpleNamespace(
+        _iniConfig=types.SimpleNamespace(config={}),
+        filteredTables=[table],
+        frontend_browser=None,
+        send_event_all_windows_incself=lambda event: events.append(event["type"]),
+    )
+
+
+def _launch_kwargs(popen):
+    # Neutral stubs for every collaborator launch_table pulls in, so the test
+    # exercises the event lifecycle without touching the real launcher, DOF, or
+    # play-tracking side effects.
+    vpxbin_path = types.SimpleNamespace(exists=lambda: True)
+    return dict(
+        get_effective_launcher=lambda vpxbin, meta: (vpxbin_path, "vpxbinpath", None),
+        build_vpx_launch_command=lambda **kwargs: ["/opt/vpx", "-play", "/tables/example.vpx"],
+        parse_launch_env_overrides=lambda raw: {},
+        resolve_launch_tableini_override=lambda *a, **k: "",
+        stop_dof_service=lambda: None,
+        stop_libdmdutil_service=lambda clear=False: None,
+        start_dof_service_if_enabled=lambda ini: None,
+        get_plugin_profile_from_meta=lambda meta: "",
+        resolve_launch_plugin_profile=lambda profile: "",
+        popen=popen,
+    )
+
+
+class LaunchServiceLifecycleTests(unittest.TestCase):
+    def _run_launch(self, popen):
+        events = []
+        api = _make_api(events)
+        with mock.patch.object(launch_service, "SettingsConfig") as settings_cls, \
+                mock.patch.object(launch_service, "delete_vpinball_log_on_start_if_configured"), \
+                mock.patch.object(launch_service.table_play_service, "track_table_play"), \
+                mock.patch.object(launch_service.table_play_service, "increment_start_count"), \
+                mock.patch.object(launch_service.table_play_service, "add_runtime_minutes"), \
+                mock.patch.object(launch_service.table_play_service, "update_score_from_nvram"), \
+                mock.patch.object(launch_service.table_play_service, "delete_nvram_if_configured"), \
+                mock.patch.object(launch_service, "save_last_table"), \
+                mock.patch.object(launch_service, "get_active_profile", return_value=None):
+            settings_cls.from_config.return_value = types.SimpleNamespace(
+                vpx_bin_path="/opt/vpx",
+                global_ini_override="",
+                global_table_ini_override_enabled=False,
+                global_table_ini_override_mask="",
+                vpx_launch_env="",
+            )
+            launch_service.launch_table(api, 0, **_launch_kwargs(popen))
+        return events
+
+    def test_complete_fires_on_normal_launch(self):
+        events = self._run_launch(lambda cmd, **kwargs: _FakePopen(["Startup done\n"]))
+        self.assertEqual(events, ["TableLaunching", "TableRunning", "TableLaunchComplete"])
+
+    def test_complete_still_emitted_when_launch_raises(self):
+        # A raising popen is the whole point of the fix: TableLaunchComplete must
+        # still go out so the frontend re-enables input, and the failure must
+        # still propagate so it gets logged upstream.
+        events = []
+        api = _make_api(events)
+
+        def boom(cmd, **kwargs):
+            raise RuntimeError("popen failed")
+
+        with mock.patch.object(launch_service, "SettingsConfig") as settings_cls, \
+                mock.patch.object(launch_service, "delete_vpinball_log_on_start_if_configured"), \
+                mock.patch.object(launch_service.table_play_service, "track_table_play"), \
+                mock.patch.object(launch_service, "save_last_table"), \
+                mock.patch.object(launch_service, "get_active_profile", return_value=None):
+            settings_cls.from_config.return_value = types.SimpleNamespace(
+                vpx_bin_path="/opt/vpx",
+                global_ini_override="",
+                global_table_ini_override_enabled=False,
+                global_table_ini_override_mask="",
+                vpx_launch_env="",
+            )
+            with self.assertRaises(RuntimeError):
+                launch_service.launch_table(api, 0, **_launch_kwargs(boom))
+
+        self.assertIn("TableLaunching", events)
+        self.assertEqual(events[-1], "TableLaunchComplete")
+
+    def test_complete_not_emitted_when_launcher_missing(self):
+        # Early return before TableLaunching -> no lifecycle events at all.
+        events = []
+        api = _make_api(events)
+        missing = types.SimpleNamespace(exists=lambda: False)
+        kwargs = _launch_kwargs(lambda cmd, **k: _FakePopen())
+        kwargs["get_effective_launcher"] = lambda vpxbin, meta: (missing, "vpxbinpath", None)
+        with mock.patch.object(launch_service, "SettingsConfig") as settings_cls:
+            settings_cls.from_config.return_value = types.SimpleNamespace(vpx_bin_path="/opt/vpx")
+            launch_service.launch_table(api, 0, **kwargs)
+        self.assertEqual(events, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
TableLaunching suppresses frontend input and TableLaunchComplete restores it,
but Complete was emitted outside the try/finally around the launch. If anything
between the two threw — a raising popen, a bad launch command, the post-launch
bookkeeping, or the nvram cleanup — Complete never fired and the frontend stayed
input-suppressed for the life of the process (the JS side won't re-enable input
on its own once the lifecycle suppressed it).

Wrap the body after TableLaunching in a try/finally so Complete always goes out,
then let the real failure keep propagating so it still gets logged. Ordering of
the DOF restart, post-launch bookkeeping, and TableRunning is unchanged. The
early returns for a missing launcher run before TableLaunching, so they don't
emit a spurious Complete.

Adds tests/test_launch_service.py covering the normal path, a raising launch
(Complete still fires and the error still propagates), and the missing-launcher
early return.

Note: this is a latent robustness fix, not the cause of any specific freeze
report.