### PR TITLE
Make the config directory relocatable (VPINFE_CONFIG_DIR / --configdir), replace dead --configfile

### DIFF
--- a/clioptions.py
+++ b/clioptions.py
@@ -99,7 +99,7 @@ def parseArgs():
     parser.add_argument("--listres", action="store_true", help="ID and list your screens")
     parser.add_argument("--listmissing", action="store_true", help="List the tables from VPSdb")
     parser.add_argument("--listunknown", action="store_true", help="List the tables we can't match in VPSdb")
-    parser.add_argument("--configfile", help="Configure the location of your vpinfe.ini file. Default is cwd.")
+    parser.add_argument("--configdir", metavar="DIR", help="Use DIR as the config directory (vpinfe.ini, themes, caches, logs) instead of the OS default. Same as the VPINFE_CONFIG_DIR env var; applied at startup in main.py.")
     parser.add_argument("--buildmeta", action="store_true", help="Builds the meta.ini file in each table dir")
     parser.add_argument("--vpxpatch", action="store_true", help="Attempt to apply patches automatically")
     parser.add_argument("--gamepadtest", action="store_true", help="Test and map your gamepad via JS API")
@@ -152,9 +152,6 @@ def parseArgs():
     if args.listunknown:
         listUnknownTables()
         sys.exit()
-
-    if args.configfile:
-        configfile = args.configfile  # TODO: wire into IniConfig if needed
 
     if args.claim_user_media:
         claimUserMedia(tableName=args.table)

--- a/common/config_bootstrap.py
+++ b/common/config_bootstrap.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import os
+from typing import MutableMapping, Sequence
+
+
+def apply_configdir_override(
+    argv: Sequence[str],
+    env: MutableMapping[str, str] | None = None,
+) -> str | None:
+    """Map a --configdir CLI flag onto the VPINFE_CONFIG_DIR environment variable.
+
+    common.paths resolves CONFIG_DIR at import time, so the config location has
+    to be in the environment before anything under common/ is imported. argparse
+    runs too late for that, so main.py peeks at argv and calls this first.
+
+    An explicit VPINFE_CONFIG_DIR already in the environment wins over the flag,
+    matching how env overrides usually beat CLI defaults. Accepts both
+    "--configdir DIR" and "--configdir=DIR". Returns the directory that was
+    applied, or None if nothing changed.
+    """
+    if env is None:
+        env = os.environ
+
+    if env.get("VPINFE_CONFIG_DIR", "").strip():
+        return None
+
+    value: str | None = None
+    for i, arg in enumerate(argv):
+        if arg == "--configdir" and i + 1 < len(argv):
+            value = argv[i + 1]
+        elif arg.startswith("--configdir="):
+            value = arg.split("=", 1)[1]
+
+    if value is not None and value.strip():
+        env["VPINFE_CONFIG_DIR"] = value
+        return value
+    return None

--- a/common/paths.py
+++ b/common/paths.py
@@ -8,7 +8,18 @@ from platformdirs import user_config_dir
 from common.iniconfig import IniConfig
 
 
-CONFIG_DIR = Path(user_config_dir("vpinfe", "vpinfe"))
+def _resolve_config_dir() -> Path:
+    # VPINFE_CONFIG_DIR lets you point the whole config directory (vpinfe.ini,
+    # themes/, caches, logs, .nicegui storage) somewhere other than the OS
+    # default. Read at import time so it also applies to frozen PyInstaller
+    # builds. Falls back to the platformdirs location when unset.
+    override = os.environ.get("VPINFE_CONFIG_DIR", "").strip()
+    if override:
+        return Path(override).expanduser()
+    return Path(user_config_dir("vpinfe", "vpinfe"))
+
+
+CONFIG_DIR = _resolve_config_dir()
 VPINFE_INI_PATH = CONFIG_DIR / "vpinfe.ini"
 COLLECTIONS_PATH = CONFIG_DIR / "collections.ini"
 THEMES_DIR = CONFIG_DIR / "themes"

--- a/docs/common.md
+++ b/docs/common.md
@@ -7,7 +7,7 @@ small facade classes for older call sites.
 
 ## Layout
 
-- `paths.py`: canonical user config, themes, collections, and table-root paths.
+- `paths.py`: canonical user config, themes, collections, and table-root paths. `CONFIG_DIR` is resolved once at import time; set `VPINFE_CONFIG_DIR` before import (main.py maps the `--configdir` flag onto it) to relocate the whole config directory.
 - `config_access.py`: typed, UI-independent accessors for common INI sections.
 - `table.py`, `tableparser.py`, `table_repository.py`: table discovery and cached table rows.
 - `table_metadata.py`, `metaconfig.py`: `.info` file schema, defaults, display helpers, and persistence.

--- a/main.py
+++ b/main.py
@@ -25,6 +25,12 @@ if "--dof-helper" in sys.argv[1:]:
     from common.dof_service_worker import main as _dof_helper_main
     raise SystemExit(_dof_helper_main())
 
+
+# common.paths resolves CONFIG_DIR at import time, so --configdir has to reach
+# the environment before anything under common/ is imported. Do it first.
+from common.config_bootstrap import apply_configdir_override
+apply_configdir_override(sys.argv[1:])
+
 from common.logging_config import configure_logging, get_logger
 from common.iniconfig import IniConfig
 from common.dof_service import start_dof_service_if_enabled, stop_dof_service

--- a/readme.md
+++ b/readme.md
@@ -98,6 +98,8 @@ NiceGUI ready to go on http://localhost:8001, and http://192.168.1.228:8001
 
 Put that URL in a browser and your in the ManagerUI.
 
+By default VPinFE keeps `vpinfe.ini`, `themes/`, caches, and logs in the OS config directory (`~/.config/vpinfe` on Linux, `~/Library/Application Support/vpinfe` on macOS, `%LOCALAPPDATA%\vpinfe` on Windows). To keep everything somewhere else — a portable install, or separate config profiles — set the `VPINFE_CONFIG_DIR` environment variable or pass `--configdir DIR`. Both point the whole config directory at `DIR`; the environment variable wins if you set both.
+
 ### Enabling the shutdown feature
 
 If you plan on using the **Shutdown** or **Reboot** option in the frontend or the remote page, some Linux systems need an explicit polkit rule so the VPinFE user can power off or reboot the machine without an interactive prompt.
@@ -808,8 +810,9 @@ options:
   --listres             ID and list your screens
   --listmissing         List the tables from VPSdb
   --listunknown         List the tables we can't match in VPSdb
-  --configfile CONFIGFILE
-                        Configure the location of your vpinfe.ini file. Default is cwd.
+  --configdir DIR       Use DIR as the config directory (vpinfe.ini, themes,
+                        caches, logs) instead of the OS default. Same as the
+                        VPINFE_CONFIG_DIR env var; applied at startup in main.py.
   --buildmeta           Builds the meta.ini file in each table dir
   --vpxpatch            Using vpx-standalone-scripts will attempt to load patches automatically
   --gamepadtest         Testing and mapping your gamepad via js api

--- a/tests/test_config_dir_override.py
+++ b/tests/test_config_dir_override.py
@@ -1,0 +1,104 @@
+import importlib
+import os
+import unittest
+from pathlib import Path
+
+import common.paths
+from common.config_bootstrap import apply_configdir_override
+
+ENV_VAR = "VPINFE_CONFIG_DIR"
+
+
+class TestConfigDirEnvOverride(unittest.TestCase):
+    """common.paths.CONFIG_DIR honors VPINFE_CONFIG_DIR at import time."""
+
+    def setUp(self) -> None:
+        self._saved = os.environ.get(ENV_VAR)
+
+    def tearDown(self) -> None:
+        if self._saved is None:
+            os.environ.pop(ENV_VAR, None)
+        else:
+            os.environ[ENV_VAR] = self._saved
+        # Leave the module resolved against the real environment for other tests.
+        importlib.reload(common.paths)
+
+    def _reload(self):
+        return importlib.reload(common.paths)
+
+    def test_override_relocates_config_dir_and_derived_paths(self) -> None:
+        os.environ[ENV_VAR] = "/tmp/vpinfe-override"
+        paths = self._reload()
+
+        self.assertEqual(paths.CONFIG_DIR, Path("/tmp/vpinfe-override"))
+        self.assertEqual(paths.VPINFE_INI_PATH, Path("/tmp/vpinfe-override/vpinfe.ini"))
+        self.assertEqual(paths.THEMES_DIR, Path("/tmp/vpinfe-override/themes"))
+        self.assertEqual(paths.COLLECTIONS_PATH, Path("/tmp/vpinfe-override/collections.ini"))
+
+    def test_override_expands_user_home(self) -> None:
+        os.environ[ENV_VAR] = "~/vpinfe-home"
+        paths = self._reload()
+
+        self.assertEqual(paths.CONFIG_DIR, Path.home() / "vpinfe-home")
+
+    def test_blank_override_falls_back_to_platformdirs(self) -> None:
+        os.environ.pop(ENV_VAR, None)
+        default = self._reload().CONFIG_DIR
+
+        os.environ[ENV_VAR] = "   "
+        self.assertEqual(self._reload().CONFIG_DIR, default)
+
+
+class TestApplyConfigdirOverride(unittest.TestCase):
+    """The CLI flag maps onto the env var before common.paths is imported."""
+
+    def test_sets_env_from_space_separated_flag(self) -> None:
+        env: dict[str, str] = {}
+        applied = apply_configdir_override(["--configdir", "/tmp/cfg"], env)
+
+        self.assertEqual(applied, "/tmp/cfg")
+        self.assertEqual(env[ENV_VAR], "/tmp/cfg")
+
+    def test_sets_env_from_equals_form(self) -> None:
+        env: dict[str, str] = {}
+        apply_configdir_override(["--configdir=/tmp/cfg"], env)
+
+        self.assertEqual(env[ENV_VAR], "/tmp/cfg")
+
+    def test_existing_env_wins_over_flag(self) -> None:
+        env = {ENV_VAR: "/already/set"}
+        applied = apply_configdir_override(["--configdir", "/tmp/cfg"], env)
+
+        self.assertIsNone(applied)
+        self.assertEqual(env[ENV_VAR], "/already/set")
+
+    def test_last_flag_wins(self) -> None:
+        env: dict[str, str] = {}
+        apply_configdir_override(["--configdir", "/first", "--configdir=/second"], env)
+
+        self.assertEqual(env[ENV_VAR], "/second")
+
+    def test_no_flag_leaves_env_untouched(self) -> None:
+        env: dict[str, str] = {}
+        applied = apply_configdir_override(["--headless", "--buildmeta"], env)
+
+        self.assertIsNone(applied)
+        self.assertNotIn(ENV_VAR, env)
+
+    def test_blank_flag_value_is_ignored(self) -> None:
+        env: dict[str, str] = {}
+        applied = apply_configdir_override(["--configdir", "   "], env)
+
+        self.assertIsNone(applied)
+        self.assertNotIn(ENV_VAR, env)
+
+    def test_trailing_flag_without_value_is_ignored(self) -> None:
+        env: dict[str, str] = {}
+        applied = apply_configdir_override(["--headless", "--configdir"], env)
+
+        self.assertIsNone(applied)
+        self.assertNotIn(ENV_VAR, env)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
--configfile has been advertised in --help for a while but never did anything.
clioptions parsed it into a local variable with a TODO and threw it away, and
it couldn't have worked where it sat: common/paths.py resolves CONFIG_DIR at
import time via platformdirs, and most of common/ imports that path directly,
so a flag parsed later in clioptions runs too late to influence it.

This makes the config directory actually relocatable:

- common/paths.py reads a VPINFE_CONFIG_DIR env var at import time and uses it
  as the config dir when set, falling back to the platformdirs location
  otherwise. Reading it at import time means it also works for frozen
  PyInstaller builds.
- main.py maps a new --configdir flag onto that env var before anything under
  common/ is imported (common/config_bootstrap.py), so the flag takes effect.
  An explicit VPINFE_CONFIG_DIR wins over the flag.

The real unit of isolation is the whole config directory -- vpinfe.ini,
themes/, caches, logs, .nicegui storage -- not a single file, so the flag is
--configdir, not --configfile. The old flag never worked, so there's no
behavior to keep compatible.

Docs: readme CLI list plus a short note on the config dir location and the
override, and docs/common.md. Tests cover both the env resolution in paths.py
and the flag-to-env mapping.

python -m unittest discover tests -> 210 passing.