### PR TITLE
Wheel paging: map Page Up/Down to jump by letter or page

### DIFF
--- a/common/iniconfig.py
+++ b/common/iniconfig.py
@@ -61,6 +61,8 @@ class IniConfig:
 				'keypageup': 'PageUp',
 				'joypagedown': '',
 				'keypagedown': 'PageDown',
+				'pagingtype': 'alpha',
+				'pagingsize': '10',
 				'joyselect': '',
 				'keyselect': 'Enter',
 				'joymenu': '',

--- a/docs/technical_details.md
+++ b/docs/technical_details.md
@@ -28,6 +28,10 @@ VPinFE uses a platform-specific configuration directory to store its settings. O
 | joyright          | Move right. Button mapping ids from `--gamepadtest`.                     |
 | joyup             | Move up. Button mapping ids from `--gamepadtest`.                        |
 | joydown           | Move down. Button mapping ids from `--gamepadtest`.                      |
+| joypageup         | Page the wheel forward. Button mapping ids from `--gamepadtest`.         |
+| joypagedown       | Page the wheel backward. Button mapping ids from `--gamepadtest`.        |
+| pagingtype        | `alpha` (default) pages by letter; `numeric` pages by `pagingsize` tables. Alpha falls back to numeric on non-Alpha sorts. |
+| pagingsize        | Tables per numeric page jump. Default is `10`.                           |
 | joyselect         | Select button / Launch. Button mapping ids from `--gamepadtest`.        |
 | joymenu           | Pop Menu. Button mapping ids from `--gamepadtest`.                       |
 | joyback           | Go Back. Button mapping ids from `--gamepadtest`.                        |

--- a/docs/theme.md
+++ b/docs/theme.md
@@ -842,6 +842,30 @@ The following actions are handled internally by VPinFECore and do **not** reach 
 | `joycollectionmenu` | Mapped button | `[Input] keycollectionmenu` (default `c`) | Toggles the collection menu overlay |
 | `joytutorial` | Mapped button | `[Input] keytutorial` (default `t`) | Toggles the Pinball Primer tutorial overlay |
 | `joyexit` | Mapped button | `[Input] keyexit` (default `Escape,q`) | Closes the application |
+| `joypageup` / `joypagedown` | Mapped button | `[Input] keypageup`/`keypagedown` (defaults `PageUp`/`PageDown`) | Pages the table wheel (see below) |
+
+#### Wheel Paging
+
+By default the core handles `joypageup`/`joypagedown` itself: it asks the backend
+where the press should land (`get_page_index`) and broadcasts a `TableIndexUpdate`
+to every window. Your theme moves its wheel through the same `receiveEvent` path it
+already uses for external index updates, so paging works with no theme changes.
+
+The user controls the behavior with two `[Input]` settings in `vpinfe.ini`:
+
+- `pagingtype` — `alpha` (default) jumps to the next/previous letter of the current
+  Alpha sort (numbers and symbols share one `#` group); `numeric` jumps by a fixed
+  number of tables. Alpha paging falls back to numeric when the active sort isn't
+  `Alpha` or the list is all one letter.
+- `pagingsize` — how many tables a numeric jump moves (default `10`). All paging wraps
+  around.
+
+A theme that wants its own paging behavior calls `vpin.enableCorePaging(false)`;
+the actions are then routed to `handleInput` like any other, and
+`vpin.getPageIndex(direction)` is available if you want the config-aware target
+index while animating the move yourself. While a core overlay (menu, collection
+menu, tutorial) is up, these actions bypass core paging and go to the overlay's
+handler regardless.
 
 ---
 
@@ -947,9 +971,10 @@ The following methods are available via `vpin.call()`:
 
 | Method | Args | Returns | Description |
 |--------|------|---------|-------------|
-| `get_joymaping` | — | `object` | Returns the gamepad button mapping from `vpinfe.ini`. Keys: `joyleft`, `joyright`, `joyup`, `joydown`, `joyselect`, `joymenu`, `joyback`, `joytutorial`, `joyexit`, `joycollectionmenu`. Values are button index strings. |
-| `get_keymapping` | — | `object` | Returns the keyboard mapping from `vpinfe.ini`. Keys: `keyleft`, `keyright`, `keyup`, `keydown`, `keyselect`, `keymenu`, `keyback`, `keytutorial`, `keyexit`, `keycollectionmenu`. Values are comma-separated browser key names or key codes. |
+| `get_joymaping` | — | `object` | Returns the gamepad button mapping from `vpinfe.ini`. Keys: `joyleft`, `joyright`, `joyup`, `joydown`, `joypageup`, `joypagedown`, `joyselect`, `joymenu`, `joyback`, `joytutorial`, `joyexit`, `joycollectionmenu`. Values are button index strings. |
+| `get_keymapping` | — | `object` | Returns the keyboard mapping from `vpinfe.ini`. Keys: `keyleft`, `keyright`, `keyup`, `keydown`, `keypageup`, `keypagedown`, `keyselect`, `keymenu`, `keyback`, `keytutorial`, `keyexit`, `keycollectionmenu`. Values are comma-separated browser key names or key codes. |
 | `set_button_mapping` | `button_name`, `button_index` | `object` | Sets a gamepad button mapping and saves to config. Returns `{success, message}`. |
+| `get_page_index` | `index`, `direction` | `number` | Returns the wheel index a page press should land on, from `index` in the given `direction` (`"next"` or `"prev"`). Honors `[Input] pagingtype`/`pagingsize` and the current sort. See [Wheel Paging](#wheel-paging). |
 
 ##### Theme & Display Config
 
@@ -1036,6 +1061,15 @@ Returns `true` when centralized core audio handling is enabled.
 
 #### setAudioOptions(options)
 Updates centralized audio options at runtime: volume (`maxVolume`, `max_volume`, or `volume`), fade duration (`fadeDuration`, `fade_duration_ms`, or `fadeMs`), and `loop`.
+
+#### enableCorePaging(enabled=true)
+Turns core-handled wheel paging (`joypageup`/`joypagedown`) on or off. Disable it if your theme does its own paging; the actions then arrive in `handleInput`. See [Wheel Paging](#wheel-paging).
+
+#### isCorePagingEnabled()
+Returns `true` when core-handled wheel paging is enabled.
+
+#### getPageIndex(direction="next", index=current)
+Asks the backend where a page press should land and returns the target index. Convenience wrapper around the `get_page_index` API method for themes doing their own paging animation.
 
 #### getTableMeta(index)
 Returns the full table object for a given table index. This is the same object as `vpin.tableData[index]`. See [Table Data Object](#table-data-object).

--- a/frontend/api.py
+++ b/frontend/api.py
@@ -62,6 +62,7 @@ API_ALLOWED_METHODS = {
     'get_filter_years',
     'apply_filters',
     'apply_sort',
+    'get_page_index',
     'reset_filters',
     'console_out',
     'get_joymaping',
@@ -301,6 +302,21 @@ class API:
         count = table_state.apply_sort(self.filteredTables, sort_type, self.current_order)
         logger.debug("Sorted %s tables by %s %s", count, sort_type, self.current_order)
         return count
+
+    def get_page_index(self, index, direction):
+        """
+        Compute the target wheel index for a page next/prev request.
+        Paging behavior comes from [Input] pagingtype/pagingsize and the
+        current sort; see table_state.page_jump_index.
+        """
+        try:
+            index = int(index)
+        except (TypeError, ValueError):
+            index = 0
+        paging_type, page_size = input_api.get_paging_config(self._iniConfig.config)
+        return table_state.page_jump_index(
+            self.filteredTables, index, direction, self.current_sort, paging_type, page_size
+        )
 
     def console_out(self, output):
         logger.info("Win: %s - %s", self.window_name, output)

--- a/frontend/input_api.py
+++ b/frontend/input_api.py
@@ -32,8 +32,27 @@ KEY_MAPPING_DEFAULTS = {
 }
 
 
+PAGING_TYPES = ("alpha", "numeric")
+PAGING_TYPE_DEFAULT = "alpha"
+PAGING_SIZE_DEFAULT = 10
+
+
 def get_joymapping(config):
     return {key: config["Input"].get(key, "0") for key in JOY_MAPPING_KEYS}
+
+
+def get_paging_config(config):
+    """Return (paging_type, page_size) from [Input], normalized to sane values."""
+    paging_type = str(config["Input"].get("pagingtype", PAGING_TYPE_DEFAULT) or "").strip().lower()
+    if paging_type not in PAGING_TYPES:
+        paging_type = PAGING_TYPE_DEFAULT
+    try:
+        page_size = int(str(config["Input"].get("pagingsize", PAGING_SIZE_DEFAULT)).strip())
+    except (TypeError, ValueError):
+        page_size = PAGING_SIZE_DEFAULT
+    if page_size < 1:
+        page_size = PAGING_SIZE_DEFAULT
+    return paging_type, page_size
 
 
 def get_keymapping(config):

--- a/frontend/table_state.py
+++ b/frontend/table_state.py
@@ -168,6 +168,48 @@ def apply_sort(tables, sort_type, order_by=None):
     return len(tables)
 
 
+def _paging_group_key(table):
+    # Letter groups for alpha paging. Titles starting with a digit or symbol all
+    # land in one '#' bucket so a big collection doesn't take several presses to
+    # cross the numeric titles.
+    title = table_title(table).strip()
+    if title and title[0].isalpha():
+        return title[0].upper()
+    return "#"
+
+
+def page_jump_index(tables, index, direction, sort_type="Alpha", paging_type="alpha", page_size=10):
+    """Return the target wheel index for a joypageup/joypagedown press.
+
+    Alpha paging jumps to the first table of the adjacent letter group in the
+    current list order. It only applies when the list is title-ordered (Alpha
+    sort); otherwise, or when the whole list is one letter group, it falls back
+    to numeric paging. Numeric paging steps by pagingsize, capped at half the
+    list so a press never wraps past the starting point. All paging is circular.
+    """
+    count = len(tables)
+    if count <= 1:
+        return 0 if count else index
+    index = index % count
+    forward = direction != "prev"
+
+    if paging_type == "alpha" and sort_type == "Alpha":
+        keys = [_paging_group_key(table) for table in tables]
+        if len(set(keys)) > 1:
+            step = 1 if forward else -1
+            pos = (index + step) % count
+            while keys[pos] == keys[index]:
+                pos = (pos + step) % count
+            if not forward:
+                # Walked back onto the previous group's last entry; rewind to its first.
+                while keys[(pos - 1) % count] == keys[pos] and (pos - 1) % count != index:
+                    pos = (pos - 1) % count
+            return pos
+
+    step = min(page_size, max(1, count // 2))
+    return (index + step) % count if forward else (index - step) % count
+
+
 def _sort_by_numeric_meta(tables, field, reverse):
     tables.sort(key=lambda table: table_title(table).lower())
     tables.sort(key=lambda table: _numeric_meta_value(table, field), reverse=reverse)

--- a/managerui/config_fields.py
+++ b/managerui/config_fields.py
@@ -6,6 +6,8 @@ INPUT_MAPPING_ACTION_ORDER = [
     "right",
     "up",
     "down",
+    "pageup",
+    "pagedown",
     "select",
     "menu",
     "back",

--- a/managerui/pages/vpinfe_config.py
+++ b/managerui/pages/vpinfe_config.py
@@ -112,6 +112,8 @@ FRIENDLY_NAMES = {
     'keyright': 'Keyboard Right',
     'keyup': 'Keyboard Up',
     'keydown': 'Keyboard Down',
+    'keypageup': 'Keyboard Page Up',
+    'keypagedown': 'Keyboard Page Down',
     'keyselect': 'Keyboard Select',
     'keymenu': 'Keyboard Menu',
     'keyback': 'Keyboard Back',
@@ -119,7 +121,11 @@ FRIENDLY_NAMES = {
     'joyright': 'Gamepad Right',
     'joyup': 'Gamepad Up',
     'joydown': 'Gamepad Down',
+    'joypageup': 'Gamepad Page Up',
+    'joypagedown': 'Gamepad Page Down',
     'joyselect': 'Gamepad Select',
+    'pagingtype': 'Paging Type',
+    'pagingsize': 'Paging Size',
     'joymenu': 'Gamepad Menu',
     'joyback': 'Gamepad Back',
     'joytutorial': 'Gamepad Tutorial',
@@ -451,6 +457,14 @@ def render_panel(tab=None):
                 inp = ui.select(
                     options=priority_options,
                     value=priority_value
+                ).props('outlined dense options-dense emit-value map-options').classes('config-input')
+            elif section == 'Input' and key == 'pagingtype':
+                normalized_paging = str(value or '').strip().lower()
+                paging_options = {'alpha': 'Alphabetic (jump by letter)', 'numeric': 'Numeric (jump by page size)'}
+                paging_value = normalized_paging if normalized_paging in paging_options else 'alpha'
+                inp = ui.select(
+                    options=paging_options,
+                    value=paging_value
                 ).props('outlined dense options-dense emit-value map-options').classes('config-input')
             elif is_checkbox:
                 inp = ui.checkbox(

--- a/readme.md
+++ b/readme.md
@@ -252,6 +252,8 @@ Gamepad button mappings stored in `vpinfe.ini`:
 - **Right**
 - **Up**
 - **Down**
+- **Page Up**
+- **Page Down**
 - **Select**
 - **Menu**
 - **Back**
@@ -265,6 +267,8 @@ Keyboard mappings are also stored in the same `[Input]` section using matching `
 - `keyright`
 - `keyup`
 - `keydown`
+- `keypageup`
+- `keypagedown`
 - `keyselect`
 - `keymenu`
 - `keyback`
@@ -275,6 +279,13 @@ Keyboard mappings are also stored in the same `[Input]` section using matching `
 These keyboard values apply only to the VPinFE frontend. They do not affect the Remote Control page. Each entry accepts a comma-separated list of browser key values or key codes such as `ArrowLeft,ShiftLeft` or `Escape,q`.
 
 You normally set these from `./vpinfe --gamepadtest`, but the values are visible and editable here.
+
+The Page Up/Page Down actions page the table wheel. Two additional `[Input]` settings control the behavior:
+
+- **Paging Type**: `alpha` (default) jumps to the next/previous letter of the alphabetically sorted wheel; `numeric` jumps by a fixed number of tables. Alpha paging falls back to numeric when the wheel isn't sorted alphabetically.
+- **Paging Size**: how many tables a numeric jump moves (default 10).
+
+The gamepad buttons are unmapped by default — map your second (magna-save) flipper buttons to Page Up/Page Down for quick wheel navigation on a cabinet.
 
 #### Logger section
 

--- a/tests/test_paging.py
+++ b/tests/test_paging.py
@@ -1,0 +1,156 @@
+import configparser
+import unittest
+from types import SimpleNamespace
+
+from frontend import input_api
+from frontend.api import API
+from frontend.table_state import page_jump_index
+
+
+def _table(title):
+    return SimpleNamespace(metaConfig={"Info": {"Title": title}})
+
+
+def _tables(*titles):
+    return [_table(title) for title in titles]
+
+
+class TestPageJumpIndexAlpha(unittest.TestCase):
+    def setUp(self):
+        # Alpha-sorted list: groups #(2), A(2), B(1), C(3)
+        self.tables = _tables(
+            "24", "4x4", "Attack", "Avalanche", "Bally Hoo", "Cactus", "Comet", "Cyclone"
+        )
+
+    def test_next_jumps_to_first_of_next_letter(self):
+        self.assertEqual(page_jump_index(self.tables, 2, "next"), 4)
+
+    def test_next_from_mid_group_skips_rest_of_group(self):
+        self.assertEqual(page_jump_index(self.tables, 5, "next"), 0)
+
+    def test_next_wraps_to_number_bucket(self):
+        self.assertEqual(page_jump_index(self.tables, 7, "next"), 0)
+
+    def test_prev_jumps_to_first_of_previous_letter(self):
+        self.assertEqual(page_jump_index(self.tables, 4, "prev"), 2)
+
+    def test_prev_from_mid_group_goes_to_previous_group_start(self):
+        self.assertEqual(page_jump_index(self.tables, 6, "prev"), 4)
+
+    def test_prev_wraps_from_number_bucket_to_last_group(self):
+        self.assertEqual(page_jump_index(self.tables, 0, "prev"), 5)
+
+    def test_numbers_and_symbols_share_one_bucket(self):
+        tables = _tables("24", "4x4", "(Secret)", "Attack")
+        self.assertEqual(page_jump_index(tables, 0, "next"), 3)
+
+    def test_descending_alpha_order_still_groups(self):
+        tables = _tables("Cactus", "Bally Hoo", "Attack", "Avalanche")
+        self.assertEqual(page_jump_index(tables, 0, "next"), 1)
+        self.assertEqual(page_jump_index(tables, 3, "prev"), 1)
+
+    def test_single_letter_group_falls_back_to_numeric(self):
+        tables = _tables("Attack", "Avalanche", "Aztec", "Airborne")
+        # Numeric fallback: step = min(10, 4 // 2) = 2
+        self.assertEqual(page_jump_index(tables, 0, "next"), 2)
+
+    def test_non_alpha_sort_falls_back_to_numeric(self):
+        result = page_jump_index(self.tables, 0, "next", sort_type="LastRun", page_size=3)
+        self.assertEqual(result, 3)
+
+
+class TestPageJumpIndexNumeric(unittest.TestCase):
+    def test_next_steps_by_page_size(self):
+        tables = _tables(*[f"T{i:02d}" for i in range(30)])
+        self.assertEqual(page_jump_index(tables, 0, "next", paging_type="numeric", page_size=10), 10)
+
+    def test_prev_steps_back_and_wraps(self):
+        tables = _tables(*[f"T{i:02d}" for i in range(30)])
+        self.assertEqual(page_jump_index(tables, 5, "prev", paging_type="numeric", page_size=10), 25)
+
+    def test_step_caps_at_half_the_list(self):
+        # 15 tables, size 10: uncapped this would land 10 ahead, which reads as
+        # moving backward 5 on a circular wheel. Cap keeps it at 7.
+        tables = _tables(*[f"T{i:02d}" for i in range(15)])
+        self.assertEqual(page_jump_index(tables, 0, "next", paging_type="numeric", page_size=10), 7)
+
+    def test_two_tables_step_one(self):
+        tables = _tables("Alpha", "Bravo")
+        self.assertEqual(page_jump_index(tables, 0, "next", paging_type="numeric", page_size=10), 1)
+
+    def test_single_table_is_noop(self):
+        tables = _tables("Alpha")
+        self.assertEqual(page_jump_index(tables, 0, "next", paging_type="numeric"), 0)
+
+    def test_empty_list_returns_index(self):
+        self.assertEqual(page_jump_index([], 3, "next"), 3)
+
+    def test_out_of_range_index_is_normalized(self):
+        tables = _tables(*[f"T{i:02d}" for i in range(10)])
+        self.assertEqual(page_jump_index(tables, 12, "next", paging_type="numeric", page_size=3), 5)
+
+
+class TestGetPagingConfig(unittest.TestCase):
+    def _config(self, **input_values):
+        parser = configparser.ConfigParser()
+        parser.add_section("Input")
+        for key, value in input_values.items():
+            parser.set("Input", key, value)
+        return parser
+
+    def test_defaults_when_unset(self):
+        self.assertEqual(input_api.get_paging_config(self._config()), ("alpha", 10))
+
+    def test_reads_configured_values(self):
+        config = self._config(pagingtype="numeric", pagingsize="25")
+        self.assertEqual(input_api.get_paging_config(config), ("numeric", 25))
+
+    def test_invalid_values_fall_back_to_defaults(self):
+        config = self._config(pagingtype="bogus", pagingsize="zero")
+        self.assertEqual(input_api.get_paging_config(config), ("alpha", 10))
+
+    def test_nonpositive_size_falls_back(self):
+        config = self._config(pagingsize="0")
+        self.assertEqual(input_api.get_paging_config(config), ("alpha", 10))
+
+
+class TestApiGetPageIndex(unittest.TestCase):
+    def _api(self, tables, sort_type="Alpha", **input_values):
+        parser = configparser.ConfigParser()
+        parser.add_section("Input")
+        for key, value in input_values.items():
+            parser.set("Input", key, value)
+        api = API.__new__(API)
+        api._iniConfig = SimpleNamespace(config=parser)
+        api.filteredTables = tables
+        api.current_sort = sort_type
+        return api
+
+    def test_alpha_paging_over_current_view(self):
+        api = self._api(_tables("Attack", "Avalanche", "Bally Hoo", "Cactus"))
+        self.assertEqual(api.get_page_index(0, "next"), 2)
+        self.assertEqual(api.get_page_index(0, "prev"), 3)
+
+    def test_numeric_config_is_honored(self):
+        api = self._api(
+            _tables(*[f"T{i:02d}" for i in range(20)]),
+            pagingtype="numeric",
+            pagingsize="5",
+        )
+        self.assertEqual(api.get_page_index(0, "next"), 5)
+
+    def test_non_alpha_sort_uses_numeric_fallback(self):
+        api = self._api(
+            _tables(*[f"T{i:02d}" for i in range(20)]),
+            sort_type="LastRun",
+            pagingsize="4",
+        )
+        self.assertEqual(api.get_page_index(0, "next"), 4)
+
+    def test_bad_index_from_theme_is_coerced(self):
+        api = self._api(_tables("Attack", "Bally Hoo", "Cactus"))
+        self.assertEqual(api.get_page_index("not-a-number", "next"), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/common/vpinfe-core.js
+++ b/web/common/vpinfe-core.js
@@ -68,6 +68,10 @@ class VPinFECore {
     this.frontendInputEnabled = true;
     this._launchInputSuppressedByLifecycle = false;
 
+    // Core-handled wheel paging (joypageup/joypagedown)
+    this._corePagingEnabled = true;
+    this._pagingInFlight = false;
+
     // menu is up?
     this.menuUP = false;
     this.collectionMenuUP = false;
@@ -232,6 +236,24 @@ class VPinFECore {
     if (!table) return null;
     if (!table.AudioPath) return null;
     return this.#convertPathToURL(table.AudioPath);
+  }
+
+  // Core handles joypageup/joypagedown by default: it asks the backend for the
+  // target index ([Input] pagingtype/pagingsize + current sort) and broadcasts a
+  // TableIndexUpdate. Themes that implement their own paging call
+  // enableCorePaging(false) and receive the actions in handleInput instead.
+  enableCorePaging(enabled = true) {
+    this._corePagingEnabled = !!enabled;
+  }
+
+  isCorePagingEnabled() {
+    return !!this._corePagingEnabled;
+  }
+
+  // Ask the backend where a page next/prev press should land. Available to
+  // themes doing their own paging animation.
+  async getPageIndex(direction = "next", index = this._currentTableIndex) {
+    return await this.call("get_page_index", index, direction);
   }
 
   enableCoreAudio(enabled = true) {
@@ -981,6 +1003,37 @@ class VPinFECore {
     }
   }
 
+  // True when core should consume a paging action itself: paging enabled, table
+  // window, and no overlay up (overlays keep receiving the raw action).
+  #shouldHandleCorePaging(action) {
+    if (action !== "joypageup" && action !== "joypagedown") return false;
+    if (!this._corePagingEnabled) return false;
+    if (this._windowName !== "table") return false;
+    if (this.menuUP || this.collectionMenuUP || this.tutorialUP) return false;
+    return true;
+  }
+
+  async #handleCorePaging(action) {
+    // One page request in flight at a time; presses during the round trip are
+    // dropped rather than queued against a stale index.
+    if (this._pagingInFlight) return;
+    this._pagingInFlight = true;
+    try {
+      // pageup advances (next letter / forward), pagedown goes back.
+      const direction = action === "joypageup" ? "next" : "prev";
+      const index = await this.call("get_page_index", this._currentTableIndex, direction);
+      if (typeof index === "number" && index >= 0 && index !== this._currentTableIndex) {
+        // Same path restorelasttable uses: themes move their wheel on the
+        // incoming TableIndexUpdate, so no theme changes are needed.
+        this.sendMessageToAllWindowsIncSelf({ type: "TableIndexUpdate", index });
+      }
+    } catch (e) {
+      this.call("console_out", `Core paging failed: ${e.message}`);
+    } finally {
+      this._pagingInFlight = false;
+    }
+  }
+
   async #triggerInputAction(action) {
     if (!this.frontendInputEnabled) return;
 
@@ -1049,6 +1102,7 @@ class VPinFECore {
       else if (action === "joymenu") this.#showmenu();
       else if (action === "joycollectionmenu") this.#showcollectionmenu();
       else if (action === "joytutorial") this.#showtutorial();
+      else if (this.#shouldHandleCorePaging(action)) this.#handleCorePaging(action);
       else this.#triggerInputAction(action);
     }
   }
@@ -1187,6 +1241,9 @@ async #onButtonPressed(buttonIndex, gamepadIndex) {
     }
     else if (action === "joytutorial" && this._windowName == "table") {
       this.#showtutorial();
+    }
+    else if (this.#shouldHandleCorePaging(action)) {
+      this.#handleCorePaging(action);
     }
     else {
       this.#triggerInputAction(action);


### PR DESCRIPTION
Map your second flipper buttons (magna-save) to the Page Up/Page Down actions and the wheel jumps to the next/previous letter of the current Alpha sort. Numbers and symbols share one `#` group. Two new `[Input]` settings control it: `pagingtype` (`alpha` default, or `numeric`) and `pagingsize` (numeric jump, default 10). Alpha falls back to numeric when the sort isn't Alpha. All jumps are circular, capped at half the list so a press never wraps past where you started.

The core handles the actions itself: it asks the backend where to land (`get_page_index`) and broadcasts a `TableIndexUpdate` — the same path `restorelasttable` uses — so all 12 registry themes get paging with zero theme changes (I verified every theme's `receiveEvent` handles a runtime index update). Themes that want their own paging call `vpin.enableCorePaging(false)` and get the actions in `handleInput` as before; carousel-desktop is the only theme that currently handles them (page-of-N since v1.9), and I'll follow up there so it either drops its cases or opts out.

Also fixes the Manager UI input section, which was missing the pageup/pagedown fields (they rendered as raw key names), and documents the actions in theme.md, which never listed them.

Tested with 19 new unit tests plus a live run on Revolution 1.2.9: letter jumps, both wrap directions, and the numeric fallback under a LastRun sort all land exactly.