### PR TITLE
Log a warning when a theme calls an unknown/disallowed API method

### DIFF
--- a/frontend/ws_bridge.py
+++ b/frontend/ws_bridge.py
@@ -133,6 +133,7 @@ class WebSocketBridge:
         args = data.get('args', [])
 
         if method not in self.ALLOWED_METHODS:
+            logger.warning("Window '%s' called disallowed/unknown API method: %s", window_name, method)
             await websocket.send(json.dumps({
                 'type': 'api_response',
                 'id': call_id,


### PR DESCRIPTION
Unknown or disallowed API calls from a theme get rejected back to the
browser, but nothing was logged server-side. A theme calling a method
that doesn't exist failed silently on the Python side, which made those
bugs hard to track down.

Adds a logger.warning in that branch so the offending window and method
name show up in the logs.