### PR TITLE
Fix restore-last-table on themes that register receiveEvent after ready

### DIFF
--- a/web/common/vpinfe-core.js
+++ b/web/common/vpinfe-core.js
@@ -436,11 +436,25 @@ class VPinFECore {
       const index = await this.call("get_initial_table_index");
       if (typeof index === "number" && index > 0 && index < this.tableData.length) {
         this._currentTableIndex = index;
+        // Themes register window.receiveEvent at varying points in their startup
+        // (some only after a couple of awaits inside vpin.ready.then). Wait for it
+        // so the restore broadcast isn't dropped by the guard in #connectWebSocket.
+        await this.#waitForReceiveEvent();
         this.sendMessageToAllWindowsIncSelf({ type: "TableIndexUpdate", index });
       }
     } catch (e) {
       this.call("console_out", `restoreInitialTable failed: ${e.message}`);
     }
+  }
+
+  // Resolve once window.receiveEvent is a function, or after the timeout so a
+  // theme that never registers one can't hang startup.
+  async #waitForReceiveEvent(timeoutMs = 2000, intervalMs = 25) {
+    const deadline = Date.now() + timeoutMs;
+    while (typeof window.receiveEvent !== "function" && Date.now() < deadline) {
+      await new Promise(resolve => setTimeout(resolve, intervalMs));
+    }
+    return typeof window.receiveEvent === "function";
   }
 
   // Register an event handler for a specific event type


### PR DESCRIPTION
restorelasttable moves the wheel to the last-launched table by broadcasting a
TableIndexUpdate during core init. That broadcast round-trips through the bridge
and is only delivered to the theme if window.receiveEvent is already registered
when it comes back. Themes that register it at the top level get it; themes that
register it inside vpin.ready.then() don't have it set yet at that point, so the
event is silently dropped and the wheel stays on the first table. slider and
slider-video both do the latter, so restore never worked on them.

The real gap is that core assumes a listener exists the moment it broadcasts,
which it never guarantees and doesn't surface when it's not true. Rather than
push a fix into each theme, this waits for window.receiveEvent to show up before
broadcasting, capped at 2s so a theme that never registers one can't hang
startup. Well-behaved themes pass the first check and see no change; the
late-registering ones now get the restore. No per-theme changes needed.