### PR TITLE
Manager UI: shared sticky save bar for config pages

### DIFF
--- a/docs/managerui.md
+++ b/docs/managerui.md
@@ -129,6 +129,30 @@ Add small, generic helpers to `managerui/ui_helpers.py` when a pattern appears a
 
 Keep feature-specific behavior in the page or a service module instead of making `ui_helpers.py` a large mixed utility file.
 
+## Config Page Save Bar
+
+Long config pages share one sticky save bar instead of a per-page footer button. The shell creates a single native `ui.footer` in `build_app()` (hidden by default, offset for the nav); pages borrow it through `attach_shell_save_bar()`:
+
+```python
+from managerui.ui_helpers import attach_shell_save_bar
+
+update_save_bar = attach_shell_save_bar(
+    count=changed_count,      # number of unsaved edits (0 = clean)
+    on_save=save_config,      # persist, then re-baseline
+    on_discard=revert_inputs, # restore the last-saved values
+    target_label=None,        # optional text after the count, e.g. a profile name
+)
+```
+
+The bar slides in only when `count()` is non-zero, so a clean page shows nothing. The page owns dirty detection; the helper owns the bar UI, the Save and Discard buttons, and cleanup. Call the returned `update()` whenever an edit may have changed, wiring it to each input:
+
+```python
+for inp in inputs.values():
+    inp.on_value_change(lambda _: update_save_bar())
+```
+
+For pages that rebuild inputs (search/filter or profile switches), wire `update_save_bar` on the newly created inputs and call `update_save_bar()` after the re-render. `ui.footer` is a top-level layout element, so the shell creates it once and hands it out with `get_shell_save_bar()`; the helper clears and hides it on navigation through `register_page_teardown()`.
+
 ## Adding Or Changing Config Fields
 
 Use `managerui/config_fields.py` for field behavior that is metadata rather than page layout.

--- a/managerui/managerui.py
+++ b/managerui/managerui.py
@@ -23,7 +23,7 @@ from .pages import logs as tab_logs
 from .page_registry import NAV_PAGES, PAGE_ALIASES
 from .services import app_control
 from .services.archive_service import cleanup_archive, create_vpxz_archive
-from .ui_helpers import load_manager_styles, nav_button
+from .ui_helpers import load_manager_styles, nav_button, run_page_teardowns, set_shell_save_bar
 from . import upload_api
 import asyncio
 import threading
@@ -245,6 +245,12 @@ def build_app(page_param: str = '', dialog_param: str = ''):
     # Main content area - offset by nav panel width (create first so toggle_nav can reference it)
     content_container = ui.column().classes('p-6 manager-content nav-expanded')
 
+    # Shell-owned native footer (Quasar QFooter). Top-level layout elements must
+    # be direct children of the page, so it's created here and hidden by default;
+    # pages that want a sticky save bar borrow it via get_shell_save_bar().
+    shell_save_bar = ui.footer(value=False, fixed=True).classes('save-shell-footer')
+    set_shell_save_bar(shell_save_bar)
+
     # Navigation panel container (fixed position on left side)
     nav_panel = ui.column().classes('fixed left-0 top-16 bottom-0 manager-nav-panel')
 
@@ -310,6 +316,9 @@ def build_app(page_param: str = '', dialog_param: str = ''):
             return
 
         current_page['value'] = page_key
+        # Tear down page-scoped elements that live outside content_container
+        # (e.g. a native ui.footer) before swapping pages.
+        run_page_teardowns()
         content_container.clear()
 
         with content_container:

--- a/managerui/pages/vpinfe_config.py
+++ b/managerui/pages/vpinfe_config.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from managerui.config_fields import is_checkbox_field, sort_input_mapping_keys
 from managerui import config_support
 from managerui.paths import COLLECTIONS_PATH, CONFIG_DIR, VPINFE_INI_PATH, THEMES_DIR
-from managerui.ui_helpers import load_page_style
+from managerui.ui_helpers import load_page_style, attach_shell_save_bar
 
 
 logger = logging.getLogger("vpinfe.manager.vpinfe_config")
@@ -1120,5 +1120,44 @@ def render_panel(tab=None):
                                         icon='stop',
                                         on_click=run_dof_test_event_stop,
                                     ).style('color: var(--neon-pink) !important; background: var(--surface) !important; border: 1px solid var(--neon-pink); border-radius: 18px; padding: 4px 10px;')
-        with ui.element('div').classes('w-full config-footer-bar'):
-            ui.button('Save Changes', icon='save', on_click=save_config).classes('px-6 py-3').style('color: var(--neon-purple) !important; background: var(--surface) !important; border: 1px solid var(--neon-purple); border-radius: 18px; padding: 4px 10px;')
+        # --- Save bar with unsaved-change tracking --------------------------
+        # Snapshot the loaded values so we can tell when the user has edits.
+        # save_config() is left as-is; the shared footer drives the UI.
+        def _norm(value):
+            return '' if value is None else str(value)
+
+        initial_raw = {
+            (section, key): inp.value
+            for section, keys in inputs.items()
+            for key, inp in keys.items()
+        }
+
+        def changed_count():
+            return sum(
+                1
+                for section, keys in inputs.items()
+                for key, inp in keys.items()
+                if _norm(inp.value) != _norm(initial_raw.get((section, key)))
+            )
+
+        def on_save():
+            save_config()
+            for section, keys in inputs.items():
+                for key, inp in keys.items():
+                    initial_raw[(section, key)] = inp.value
+
+        def on_discard():
+            for (section, key), value in initial_raw.items():
+                inp = inputs.get(section, {}).get(key)
+                if inp is not None:
+                    inp.value = value
+
+        update_save_bar = attach_shell_save_bar(
+            count=changed_count, on_save=on_save, on_discard=on_discard
+        )
+
+        for section, keys in inputs.items():
+            for key, inp in keys.items():
+                inp.on_value_change(lambda _: update_save_bar())
+
+        update_save_bar()

--- a/managerui/pages/vpinplay.py
+++ b/managerui/pages/vpinplay.py
@@ -14,7 +14,7 @@ from common.vpinplay_service import sync_installed_tables
 from managerui.config_fields import is_checkbox_field
 from managerui.pages.vpinfe_config import get_friendly_name
 from managerui.paths import VPINFE_INI_PATH
-from managerui.ui_helpers import load_page_style
+from managerui.ui_helpers import load_page_style, attach_shell_save_bar
 
 
 logger = logging.getLogger("vpinfe.manager.vpinplay")
@@ -391,8 +391,33 @@ def render_panel():
                             )
                             update_vpinplay_qr()
 
-        with ui.element("div").classes("w-full config-footer-bar"):
-            ui.button("Save Changes", icon="save", on_click=save_config).classes("px-6 py-3").style(
-                "color: var(--neon-purple) !important; background: var(--surface) !important; "
-                "border: 1px solid var(--neon-purple); border-radius: 18px; padding: 4px 10px;"
+        # --- Save bar (shared shell footer) --------------------------------
+        def _norm(value):
+            return "" if value is None else str(value)
+
+        initial_raw = {key: inp.value for key, inp in inputs[SECTION].items()}
+
+        def changed_count():
+            return sum(
+                1
+                for key, inp in inputs[SECTION].items()
+                if _norm(inp.value) != _norm(initial_raw.get(key))
             )
+
+        def on_save():
+            save_config()
+            for key, inp in inputs[SECTION].items():
+                initial_raw[key] = inp.value
+
+        def on_discard():
+            for key, value in initial_raw.items():
+                inp = inputs[SECTION].get(key)
+                if inp is not None:
+                    inp.value = value
+
+        update_save_bar = attach_shell_save_bar(
+            count=changed_count, on_save=on_save, on_discard=on_discard
+        )
+        for inp in inputs[SECTION].values():
+            inp.on_value_change(lambda _: update_save_bar())
+        update_save_bar()

--- a/managerui/pages/vpx_config.py
+++ b/managerui/pages/vpx_config.py
@@ -12,7 +12,7 @@ from common.iniconfig import IniConfig
 from managerui.paths import CONFIG_DIR, VPINFE_INI_PATH
 from managerui.services import vpx_config_service
 from managerui.services.vpx_config_service import FieldMeta, ParsedIni, SectionMeta
-from managerui.ui_helpers import load_page_style
+from managerui.ui_helpers import load_page_style, attach_shell_save_bar
 
 
 logger = logging.getLogger("vpinfe.manager.vpx_config")
@@ -300,6 +300,7 @@ def render_panel() -> None:
             pending_reload["value"] = False
             reload_banner.refresh()
             render_filtered_sections.refresh()
+            update_save_bar()
             ui.notify("VPinballX.ini reloaded from disk", type="info")
 
         def dismiss_reload() -> None:
@@ -585,6 +586,7 @@ def render_panel() -> None:
                                             placeholder="Blank = VPX default",
                                         ).props("outlined dense").classes("w-full vpx-config-input")
                                         inputs[name][field.key] = inp
+                                        inp.on_value_change(lambda _: update_save_bar())
 
         def on_search_change() -> None:
             search_state["query"] = str(search_input.value or "")
@@ -596,14 +598,40 @@ def render_panel() -> None:
 
         search_input.on_value_change(lambda _: on_search_change())
         non_default_only.on_value_change(lambda _: on_non_default_change())
+
+        # --- Save bar (shared shell footer) --------------------------------
+        # Reuse the existing baseline (each field's loaded value) as the dirty
+        # source, so this coexists with the disk-reload watcher.
+        def _norm(value):
+            return "" if value is None else str(value)
+
+        def changed_count():
+            count = 0
+            for section in displayed_sections:
+                name = section["name"]
+                for field in section["fields"]:
+                    inp = inputs.get(name, {}).get(field.key)
+                    if inp is None:
+                        continue
+                    if _norm(inp.value).strip() != _norm(field.value).strip():
+                        count += 1
+            return count
+
+        def on_discard():
+            for section in displayed_sections:
+                name = section["name"]
+                for field in section["fields"]:
+                    inp = inputs.get(name, {}).get(field.key)
+                    if inp is not None:
+                        inp.value = field.value
+
+        update_save_bar = attach_shell_save_bar(
+            count=changed_count, on_save=save_config, on_discard=on_discard
+        )
+
         render_filtered_sections()
+        update_save_bar()
 
         # Watch VPinballX.ini for external changes (e.g. VPX rewriting it when a
         # table exits) and reload so stale values can't be saved back over them.
         ui.timer(0.5, check_disk_changes)
-
-        with ui.element("div").classes("w-full vpx-config-footer"):
-            ui.button("Save Changes", icon="save", on_click=save_config).classes("px-6 py-3").style(
-                "color: var(--neon-cyan) !important; background: var(--surface) !important; "
-                "border: 1px solid var(--neon-cyan); border-radius: 18px; padding: 4px 10px;"
-            )

--- a/managerui/pages/vpx_plugins.py
+++ b/managerui/pages/vpx_plugins.py
@@ -10,7 +10,7 @@ from managerui.services.plugin_profile_service import (
     DEFAULT_PROFILE_NAME,
     PLUGIN_PROFILES_DIR,
 )
-from managerui.ui_helpers import load_page_style
+from managerui.ui_helpers import load_page_style, attach_shell_save_bar
 
 
 logger = logging.getLogger("vpinfe.manager.vpx_plugins")
@@ -127,6 +127,7 @@ def render_panel() -> None:
             inputs.clear()
             target_label.set_text(str(path))
             render_plugins.refresh()
+            update_save_bar()
             return True
 
         def on_profile_change(event) -> None:
@@ -220,10 +221,6 @@ def render_panel() -> None:
                     .classes("vpx-plugins-profile-select")
                 )
                 ui.space()
-                ui.button("Save", icon="save", on_click=save_profile).style(
-                    "color: var(--neon-cyan) !important; background: var(--surface) !important; "
-                    "border: 1px solid var(--neon-cyan); border-radius: 18px; padding: 4px 14px;"
-                )
                 ui.button("New", icon="add", on_click=new_profile_dialog).style(
                     "color: var(--neon-purple) !important; background: var(--surface) !important; "
                     "border: 1px solid var(--neon-purple); border-radius: 18px; padding: 4px 14px;"
@@ -282,6 +279,41 @@ def render_panel() -> None:
                                         placeholder="Blank = VPX default",
                                     ).props("outlined dense").classes("w-full vpx-config-input")
                                     inputs[name][plugin_field.key] = inp
+                                    inp.on_value_change(lambda _: update_save_bar())
+
+        # --- Save bar (shared shell footer) --------------------------------
+        # Baseline is each field's loaded value; the status names the profile so
+        # it's clear which profile a save writes to.
+        def _norm(value):
+            return "" if value is None else str(value)
+
+        def changed_count():
+            count = 0
+            for section in state["sections"]:
+                name = section["name"]
+                for field in section["fields"]:
+                    inp = inputs.get(name, {}).get(field.key)
+                    if inp is None:
+                        continue
+                    if _norm(inp.value).strip() != _norm(field.value).strip():
+                        count += 1
+            return count
+
+        def on_discard():
+            for section in state["sections"]:
+                name = section["name"]
+                for field in section["fields"]:
+                    inp = inputs.get(name, {}).get(field.key)
+                    if inp is not None:
+                        inp.value = field.value
+
+        update_save_bar = attach_shell_save_bar(
+            count=changed_count,
+            on_save=save_profile,
+            on_discard=on_discard,
+            target_label=lambda: state["profile"],
+        )
 
         load_profile(DEFAULT_PROFILE_NAME)
         render_plugins()
+        update_save_bar()

--- a/managerui/static/manager.css
+++ b/managerui/static/manager.css
@@ -205,3 +205,46 @@ body::before {
 .version-link:hover {
   color: var(--neon-cyan) !important;
 }
+
+/* Shared sticky save bar (native QFooter, borrowed by config pages) */
+.q-footer.save-shell-footer {
+  left: 206px;
+  right: 14px;
+  background: var(--surface);
+  border-top: 1px solid var(--line);
+  padding: 0.5rem 1.5rem;
+  transition: left 0.3s ease;
+}
+body.nav-is-collapsed .q-footer.save-shell-footer {
+  left: 40px;
+}
+.save-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+.save-bar-status {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-right: auto;
+  font-size: 0.8rem;
+  color: var(--ink-muted);
+}
+.save-bar-pip {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--line);
+  transition: background 0.2s, box-shadow 0.2s;
+}
+.save-bar.is-dirty .save-bar-status {
+  color: var(--ink);
+}
+.save-bar.is-dirty .save-bar-pip {
+  background: var(--neon-purple);
+  box-shadow: 0 0 4px rgba(180, 41, 249, 0.55), 0 0 12px rgba(180, 41, 249, 0.35);
+}
+.save-bar.is-clean .save-bar-save {
+  opacity: 0.5;
+}

--- a/managerui/static/vpinfe_config.css
+++ b/managerui/static/vpinfe_config.css
@@ -282,14 +282,6 @@
         .config-display-item strong {
             color: var(--ink);
         }
-        .config-footer-bar {
-            position: sticky;
-            bottom: 0.75rem;
-            z-index: 5;
-            display: flex;
-            justify-content: flex-end;
-            padding-top: 0.25rem;
-        }
         .q-tab-panels {
             background: transparent !important;
         }

--- a/managerui/static/vpx_config.css
+++ b/managerui/static/vpx_config.css
@@ -104,14 +104,6 @@
                 color: var(--ink) !important;
                 font-family: monospace !important;
             }
-            .vpx-config-footer {
-                position: sticky;
-                bottom: 0.75rem;
-                z-index: 5;
-                display: flex;
-                justify-content: flex-end;
-                padding-top: 0.25rem;
-            }
             .q-tab-panels,
             .q-tab-panel {
                 background: transparent !important;

--- a/managerui/ui_helpers.py
+++ b/managerui/ui_helpers.py
@@ -14,6 +14,100 @@ def load_manager_styles() -> None:
     load_page_style("manager.css")
 
 
+# Per-client teardown callbacks for elements that live outside content_container
+# (e.g. a native ui.footer, which attaches to the page QLayout and so is not
+# removed by content_container.clear()). The shell runs these when navigating
+# between pages so such elements don't leak onto the next page.
+_page_teardowns: dict[str, list] = {}
+
+
+def register_page_teardown(fn) -> None:
+    """Register a callback to run when the shell navigates away from this page."""
+    _page_teardowns.setdefault(ui.context.client.id, []).append(fn)
+
+
+# The shell owns a single native ui.footer (a top-level layout element, which
+# NiceGUI requires to be a direct child of the page). Pages that need a sticky
+# save bar borrow it: fill it on render, empty + hide it on teardown.
+_shell_save_bars: dict[str, object] = {}
+
+
+def set_shell_save_bar(footer) -> None:
+    _shell_save_bars[ui.context.client.id] = footer
+
+
+def get_shell_save_bar():
+    return _shell_save_bars.get(ui.context.client.id)
+
+
+def attach_shell_save_bar(*, count, on_save, on_discard, target_label=None):
+    """Fill the shell footer with the slide-up save bar for the current page.
+
+    The page supplies its own dirty-state logic:
+      - count():        number of unsaved edits (0 = clean)
+      - on_save():      persist the edits and re-baseline
+      - on_discard():   revert the inputs to the last-saved values
+      - target_label(): optional str shown after the count (e.g. a profile name)
+
+    Returns an update() callable; call it whenever an edit may have changed so the
+    bar restyles and slides in/out. The footer is emptied and hidden on teardown.
+    """
+    footer = get_shell_save_bar()
+    if footer is None:
+        return lambda: None
+
+    footer.clear()
+    footer.value = False
+    with footer:
+        with ui.element('div').classes('w-full save-bar is-clean') as bar:
+            with ui.element('div').classes('save-bar-status'):
+                ui.element('div').classes('save-bar-pip')
+                status = ui.label('All changes saved')
+            discard_btn = ui.button('Discard', icon='undo', on_click=lambda: _discard()).props('flat')
+            discard_btn.style('color: var(--ink-muted) !important; border-radius: 18px; padding: 4px 10px;')
+            discard_btn.set_visibility(False)
+            save_btn = outline_action_button('Save Changes', 'save', on_click=lambda: _save())
+            save_btn.classes('save-bar-save')
+            save_btn.disable()
+
+    def update():
+        n = count()
+        dirty = n > 0
+        bar.classes(remove='is-clean is-dirty', add='is-dirty' if dirty else 'is-clean')
+        (save_btn.enable if dirty else save_btn.disable)()
+        discard_btn.set_visibility(dirty)
+        if dirty:
+            text = f"{n} unsaved change{'s' if n != 1 else ''}"
+            label = target_label() if target_label else None
+            if label:
+                text += f" → {label}"
+            status.set_text(text)
+        else:
+            status.set_text('All changes saved')
+        # Slide-up: Quasar animates the footer in only when there are edits.
+        footer.value = dirty
+
+    def _save():
+        on_save()
+        update()
+
+    def _discard():
+        on_discard()
+        update()
+
+    register_page_teardown(lambda: (footer.clear(), setattr(footer, 'value', False)))
+    return update
+
+
+def run_page_teardowns() -> None:
+    """Run and clear the teardown callbacks registered for the current client."""
+    for fn in _page_teardowns.pop(ui.context.client.id, []):
+        try:
+            fn()
+        except Exception:
+            pass
+
+
 def nav_button(label: str, icon: str, on_click, tooltip: str | None = None):
     button = (
         ui.button(label, icon=icon, on_click=on_click)


### PR DESCRIPTION
The config pages (VPinFE Config, VPX Config, VPX-Plugins, VPinPlay) put Save in a footer styled `position: sticky`, but that doesn't pin inside the shell's nested flex/scroll layout, so on long pages Save scrolled off and was hard to reach.

This adds one native `ui.footer` to the shell and a shared `attach_shell_save_bar` helper the config pages borrow. The bar slides up only when there are unsaved edits, shows the change count and a Discard, and clears itself on navigation. It follows the nav when collapsed.

- The shell owns a single `QFooter`; each page provides its own dirty detection via `count` / `on_save` / `on_discard`.
- VPX Config reuses its existing unsaved-edit check, so the bar coexists with the disk-reload watcher.
- VPX-Plugins moves Save out of the profile toolbar into the bar and names the target profile in the status.
- New "Config Page Save Bar" section in `docs/managerui.md`.

Five commits, one per surface.