### PR TITLE
Run the test suite in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,10 +2,10 @@ name: Build VPinFE (Cross-Platform)
 
 on:
   push:
-    branches: [ master, vpinfe-2.0 ]
+    branches: [ master, vpinfe-2.0, platform ]
     tags: [ 'v*' ]
   pull_request:
-    branches: [ master, vpinfe-2.0 ]
+    branches: [ master, vpinfe-2.0, platform ]
 
 permissions:
   contents: write

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,35 @@
+name: Tests
+
+on:
+  push:
+    branches: [ master, platform ]
+  pull_request:
+    branches: [ master, platform ]
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+          cache: pip
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      # The suite doesn't need the DOF/libdmdutil bundles or Chromium the build
+      # job fetches, so this stays a fast check that runs on its own.
+      - name: Run tests
+        run: python -m unittest discover tests

--- a/tests/test_asset_upload_services.py
+++ b/tests/test_asset_upload_services.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+
 import unittest
 from unittest import mock
 
@@ -262,6 +264,8 @@ class AssetAnalyzerTests(unittest.TestCase):
     def test_missing_rar_tool_reported_before_dialog(self):
         from pathlib import Path
         from tempfile import TemporaryDirectory
+
+        from managerui.services.asset_analyzer_service import rar_tool_hint
         with TemporaryDirectory() as tmp:
             fake_rar = Path(tmp) / "x.rar"
             fake_rar.write_bytes(b"x")
@@ -270,7 +274,7 @@ class AssetAnalyzerTests(unittest.TestCase):
                 fake_open.return_value = mock.Mock(kind="rar", name="x.rar")
                 result = analyze_path(fake_rar)
             self.assertEqual(result.assets, ())
-            self.assertIn("unar", result.error)
+            self.assertIn(rar_tool_hint(), result.error)
 
     def test_rar_backend_missing_is_graceful(self):
         from pathlib import Path
@@ -388,7 +392,7 @@ class SelectPlanItemsTests(unittest.TestCase):
             renamed = select_plan_items(plan, new_table_dir_name="Renamed MM")
             self.assertEqual(renamed.new_table_dir_name, "Renamed MM")
             for item in renamed.items:
-                self.assertIn("/Renamed MM/", item.destination)
+                self.assertIn(f"{os.sep}Renamed MM{os.sep}", item.destination)
 
     def test_blank_rename_raises(self):
         from tempfile import TemporaryDirectory

--- a/tests/test_common_architecture.py
+++ b/tests/test_common_architecture.py
@@ -1,3 +1,4 @@
+import os
 import configparser
 import json
 import unittest
@@ -194,7 +195,8 @@ class TestCommonArchitecture(unittest.TestCase):
         self.assertTrue(SettingsConfig.from_config(parser).disable_default_chrome_options)
 
     def test_media_paths_apply_and_payload_use_shared_specs(self) -> None:
-        table = SimpleNamespace(fullPathTable="/tmp/Table", TableImagePath=None, BGImagePath=None)
+        root = os.path.join(os.sep, "tmp", "Table")
+        table = SimpleNamespace(fullPathTable=root, TableImagePath=None, BGImagePath=None)
 
         apply_media_paths(
             table,
@@ -203,10 +205,11 @@ class TestCommonArchitecture(unittest.TestCase):
             table_type="fss",
         )
 
-        self.assertEqual(table.BGImagePath, "/tmp/Table/bg.png")
-        self.assertEqual(table.TableImagePath, "/tmp/Table/medias/fss.png")
+        self.assertEqual(table.BGImagePath, os.path.join(root, "bg.png"))
+        self.assertEqual(table.TableImagePath, os.path.join(root, "medias", "fss.png"))
         self.assertEqual(media_filename_map("fss")["fss"], "fss.png")
-        self.assertEqual(table_media_payload(table)["TableImagePath"], "/tmp/Table/medias/fss.png")
+        self.assertEqual(table_media_payload(table)["TableImagePath"],
+                         os.path.join(root, "medias", "fss.png"))
 
     def test_claim_media_for_table_uses_dynamic_table_type_keys(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_frontend_services.py
+++ b/tests/test_frontend_services.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import configparser
 import json
 import types
+import os
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -29,7 +30,14 @@ class FrontendServiceTests(unittest.TestCase):
                 )
 
             self.assertFalse((config_dir / ".restart").exists())
-            self.assertEqual(calls, [(system_actions.sys.executable, [system_actions.sys.executable, "/app/main.py"])])
+            # The code passes main_script through os.path.abspath, which on Windows
+            # prefixes the current drive. Expect what it actually builds.
+            main_script = os.path.abspath(Path("/app/main.py"))
+            self.assertEqual(
+                calls,
+                [(system_actions.sys.executable,
+                  [system_actions.sys.executable, main_script])],
+            )
 
     def test_theme_config_missing_file_is_optional(self):
         parser = configparser.ConfigParser()

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -15,12 +16,10 @@ from common.launcher import (
 
 class TestLauncherTableIniOverride(unittest.TestCase):
     def test_build_masked_tableini_path_enabled_builds_expected_name(self) -> None:
-        vpx = "/tables/300 (Gottlieb 1975) team scampa123 mod v1.1.vpx"
+        stem = "300 (Gottlieb 1975) team scampa123 mod v1.1"
+        vpx = os.path.join(os.sep, "tables", f"{stem}.vpx")
         got = build_masked_tableini_path(vpx, True, "windows")
-        self.assertEqual(
-            got,
-            "/tables/300 (Gottlieb 1975) team scampa123 mod v1.1.windows.ini",
-        )
+        self.assertEqual(got, os.path.join(os.sep, "tables", f"{stem}.windows.ini"))
 
     def test_build_masked_tableini_path_disabled_returns_empty(self) -> None:
         vpx = "/tables/example.vpx"


### PR DESCRIPTION
The build workflow only packages the app, so nothing has been running the tests.
This adds a separate job for them.

It's its own workflow rather than a step in the build matrix because the suite
needs nothing but requirements.txt - no DOF or libdmdutil bundles, no Chromium -
so it finishes in seconds and reports independently of a build. Runs on Linux,
Windows and macOS.

Also adds `platform` to the build workflow's branch triggers, the same way
`vpinfe-2.0` is listed. That's for a longer-lived branch I'm starting for
foundation work across the codebase - API, conventions, structure.

Running the suite on Windows for the first time turned up five tests that only
ever worked on POSIX - hardcoded forward slashes in paths the code builds with
os.path, and one asserting the RAR hint names `unar` when on Windows it correctly
names UnRAR.exe. The code was fine; the assertions weren't. Fixed here so the new
job goes green.
