### PR TITLE
Fix remote launch on Linux

### DIFF
--- a/managerui/pages/remote.py
+++ b/managerui/pages/remote.py
@@ -2,6 +2,7 @@ import platform
 import subprocess
 import os
 import logging
+import sys
 from nicegui import ui, run
 from managerui.paths import VPINFE_INI_PATH
 from managerui.remote_actions import PINMAME_SERVICE_CONTROLS, SYSTEM_CONTROLS, RemoteAction

--- a/managerui/pages/remote.py
+++ b/managerui/pages/remote.py
@@ -208,11 +208,12 @@ def _launch_table(table: dict):
         thread.start()
         return True
     except Exception as e:
+        logger.exception("Remote launch failed")
         set_remote_launch_state(False, None)
         try:
             start_dof_service_if_enabled(_get_ini_config())
         except Exception:
-            pass
+            logger.exception("Could not restart DOF after a failed remote launch")
         ui.notify(f'Failed to launch: {e}', type='negative')
         return False
 


### PR DESCRIPTION
`managerui/pages/remote.py` reads `getattr(sys, "frozen", False)` when it sets up
LD_LIBRARY_PATH, but never imports `sys`. The line is guarded by
`system == "Linux"`, so the name only ever gets evaluated there - launching a
table from the Remote Control page raises NameError on Linux and the page just
reports "Failed to launch". Windows and macOS short-circuit before it and are
fine.

Been that way since a01f6e5. One import.

The second commit is why it wasn't obvious: the `except` in `_launch_table` only
put the error in a toast in the browser, so nothing ever reached the log. It logs
now, and so does a failed DOF restart - if that one fails the cabinet is left
without feedback hardware and the log should say so.
