### PR TITLE
score_parser: drop the dead roms.json candidate paths

### DIFF
--- a/common/score_parser.py
+++ b/common/score_parser.py
@@ -195,27 +195,11 @@ special_text_score_files = {
 }
 
 def get_roms_candidate_paths() -> list[Path]:
-    candidate_paths: list[Path] = [
-        Path(__file__).with_name("resources") / "roms.json",
-        USER_ROMS_PATH,
-    ]
-
-    meipass = getattr(sys, "_MEIPASS", None)
-    if meipass:
-        candidate_paths.append(Path(meipass) / "common" / "resources" / "roms.json")
-
-    exe_dir = Path(sys.executable).resolve().parent
-    candidate_paths.extend(
-        [
-            exe_dir / "common" / "resources" / "roms.json",
-            exe_dir / "_internal" / "common" / "resources" / "roms.json",
-            exe_dir.parent / "Resources" / "common" / "resources" / "roms.json",
-        ]
-    )
-
-    candidates = list(dict.fromkeys(candidate_paths))
-
-    return candidates
+    # roms.json is not shipped with the build. It is downloaded into the user
+    # config dir at startup by common/pinmame_score_parser_updater.py, so that
+    # is the only place it can be. Don't add paths under the source tree or the
+    # frozen bundle back here without also adding them to build.yml.
+    return [USER_ROMS_PATH]
 
 
 def get_roms_path() -> Path:
@@ -229,19 +213,8 @@ def get_roms_path() -> Path:
     )
 
 def load_roms() -> dict:
-    merged_roms: dict = {}
-    existing_paths = [path for path in get_roms_candidate_paths() if path.exists()]
-    if not existing_paths:
-        raise FileNotFoundError(
-            "Could not find roms.json. Checked: "
-            + ", ".join(str(path) for path in get_roms_candidate_paths())
-        )
-
-    for roms_path in existing_paths:
-        with roms_path.open("r", encoding="utf-8") as f:
-            merged_roms.update(json.load(f))
-
-    return merged_roms
+    with get_roms_path().open("r", encoding="utf-8") as f:
+        return json.load(f)
 
 
 roms = load_roms()

--- a/tests/test_score_parser.py
+++ b/tests/test_score_parser.py
@@ -25,12 +25,22 @@ from common.score_parser import ParsedEntry, result_to_jsonable
 
 
 class TestScoreParser(unittest.TestCase):
-    def test_get_roms_path_prefers_user_config_copy(self) -> None:
+    def test_get_roms_path_resolves_to_the_user_config_copy(self) -> None:
         with TemporaryDirectory() as temp_dir:
             roms_path = Path(temp_dir) / "roms.json"
             roms_path.write_text('{"foo": {"scoretype": "HIGH SCORE"}}', encoding="utf-8")
             with mock.patch.object(score_parser, "USER_ROMS_PATH", roms_path):
+                self.assertEqual(score_parser.get_roms_candidate_paths(), [roms_path])
                 self.assertEqual(score_parser.get_roms_path(), roms_path)
+
+    def test_get_roms_path_error_names_the_path_it_checked(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            missing_path = Path(temp_dir) / "roms.json"
+            with mock.patch.object(score_parser, "USER_ROMS_PATH", missing_path):
+                with self.assertRaises(FileNotFoundError) as ctx:
+                    score_parser.get_roms_path()
+
+        self.assertIn(str(missing_path), str(ctx.exception))
 
     def test_result_to_jsonable_returns_direct_score_payload_for_scalar_scores(self) -> None:
         result = result_to_jsonable("agent777", 123456)


### PR DESCRIPTION
`get_roms_candidate_paths()` checks six locations for `roms.json`. Five of them can't ever resolve.

roms.json stopped shipping with the build in 17bef71 — that commit deleted `common/resources/roms.json` and removed the `--add-data "common/resources:common/resources"` lines from build.yml, and cut `get_roms_path()` down to just the user config dir. Two weeks later d7c026c ("fix race condtion on start when device is absent with libdmdutil") pulled the old candidate list back in alongside the libdmdutil change. 6c09a2c then split it out into `get_roms_candidate_paths()` and had `load_roms()` merge across every candidate that exists.

So the probes for `common/resources`, `sys._MEIPASS`, and the three spots next to the executable are all left over from before the split. `common/resources` isn't in the tree, and build.yml still doesn't `--add-data` it, so none of them can resolve in a source run or a frozen one. `USER_ROMS_PATH` (`CONFIG_DIR/roms.json`, where `pinmame_score_parser_updater` downloads it at startup) is the only one that ever hits.

This drops the list to that one path, with a note pointing at the updater and build.yml so they don't come back by accident. `load_roms()` no longer merges across candidates — with a single path that implied a precedence that isn't there. `get_roms_path()` and its `FileNotFoundError` are unchanged; it still names what it checked.

The test now asserts the list is exactly `[USER_ROMS_PATH]`, which is what would have caught the d7c026c revert, plus one for the error text.
