### PR TITLE
httpapi: make capability residency a list

### DIFF
--- a/docs/http_api.md
+++ b/docs/http_api.md
@@ -158,7 +158,7 @@ from httpapi import capabilities
 
 capabilities.declare(capabilities.Capability(
     name="peripherals",
-    residency=capabilities.RESIDENCY_PLAY_HOST,
+    residency=[capabilities.RESIDENCY_PLAY_HOST],
     description="DOF and real-DMD output",
     is_available=lambda: (dof_configured(), "DOF is not configured"),
 ))
@@ -168,9 +168,15 @@ capabilities.declare(capabilities.Capability(
 user changes a setting. Return `(False, reason)` rather than a bare `False` — the reason is
 shown to users, so say what's missing and how to fix it.
 
-`residency` records where a capability has to run: `catalog` for things that only need the
-library (location-independent, cacheable) and `play_host` for things tied to the machine
+`residency` records which roles a capability lives in: `catalog` for things that only need
+the library (location-independent, cacheable) and `play_host` for things tied to the machine
 where tables launch and hardware lives.
+
+It's a list because some capabilities belong to both — the event stream carries library
+events and launch events alike. Listing both means each role serves its own, not that one
+capability spans the two: if the catalog and the play host are ever separate machines, they
+each have an event stream, carrying their own events. Test for a role with
+`"play_host" in residency`, which reads the same whether a capability has one or two.
 
 ## Table identity
 

--- a/httpapi/capabilities.py
+++ b/httpapi/capabilities.py
@@ -6,13 +6,17 @@ Nothing is declared until the endpoints backing it land. See docs/http_api.md.
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from typing import Any
 
-# Residency: where a capability has to run. Clients hold neither.
+# Residency: which roles a capability lives in. Listing both means each role serves
+# its own, not that one capability spans the two - so if the catalog and the play
+# host are ever separate machines, both have it. Clients hold no residency at all.
 RESIDENCY_CATALOG = "catalog"
 RESIDENCY_PLAY_HOST = "play_host"
+
+RESIDENCIES = frozenset({RESIDENCY_CATALOG, RESIDENCY_PLAY_HOST})
 
 
 @dataclass(frozen=True)
@@ -21,9 +25,18 @@ class Capability:
     answer stays honest after a config change; return (False, reason), not bare False."""
 
     name: str
-    residency: str
+    residency: Sequence[str]
     description: str = ""
     is_available: Callable[[], bool | tuple[bool, str]] | None = None
+
+    def __post_init__(self) -> None:
+        # A bare string would iterate into single characters and reach discovery
+        # looking like a list of nine residencies, so it is rejected by name.
+        if isinstance(self.residency, str) or not self.residency:
+            raise ValueError(f"{self.name}: residency is a non-empty list of {sorted(RESIDENCIES)}")
+        unknown = sorted(set(self.residency) - RESIDENCIES)
+        if unknown:
+            raise ValueError(f"{self.name}: unknown residency {unknown}")
 
     def resolve(self) -> dict[str, Any]:
         available, reason = True, None
@@ -39,7 +52,7 @@ class Capability:
                     available = bool(result)
         return {
             "name": self.name,
-            "residency": self.residency,
+            "residency": list(self.residency),
             "description": self.description,
             "available": available,
             "reason": reason,

--- a/httpapi/core_capabilities.py
+++ b/httpapi/core_capabilities.py
@@ -34,22 +34,22 @@ def declare_core() -> None:
     """Declare the capabilities this build actually serves."""
     capabilities.declare(capabilities.Capability(
         name="library",
-        residency=capabilities.RESIDENCY_CATALOG,
+        residency=[capabilities.RESIDENCY_CATALOG],
         description="Table inventory, identity, metadata and media",
     ))
     capabilities.declare(capabilities.Capability(
         name="acquisition",
-        residency=capabilities.RESIDENCY_CATALOG,
+        residency=[capabilities.RESIDENCY_CATALOG],
         description="Upload sessions and the asset import pipeline",
     ))
     capabilities.declare(capabilities.Capability(
         name="play",
-        residency=capabilities.RESIDENCY_PLAY_HOST,
+        residency=[capabilities.RESIDENCY_PLAY_HOST],
         description="Launch lifecycle state for this machine",
     ))
     capabilities.declare(capabilities.Capability(
         name="peripherals",
-        residency=capabilities.RESIDENCY_PLAY_HOST,
+        residency=[capabilities.RESIDENCY_PLAY_HOST],
         description="DOF, real-DMD and other attached devices",
         is_available=_peripherals_available,
     ))

--- a/tests/test_auth_boundary.py
+++ b/tests/test_auth_boundary.py
@@ -149,8 +149,8 @@ class CapabilityTests(unittest.TestCase):
     def test_discovery_reports_residency_for_each_capability(self) -> None:
         declared = {c["name"]: c for c in _client().get("/").json()["capabilities"]}
 
-        self.assertEqual(declared["library"]["residency"], capabilities.RESIDENCY_CATALOG)
-        self.assertEqual(declared["play"]["residency"], capabilities.RESIDENCY_PLAY_HOST)
+        self.assertEqual(declared["library"]["residency"], [capabilities.RESIDENCY_CATALOG])
+        self.assertEqual(declared["play"]["residency"], [capabilities.RESIDENCY_PLAY_HOST])
 
     def test_an_unavailable_capability_says_why(self) -> None:
         """The reason is shown to users, so 'no' on its own is not good enough."""

--- a/tests/test_http_api.py
+++ b/tests/test_http_api.py
@@ -55,12 +55,12 @@ class DiscoveryTests(unittest.TestCase):
         self._isolated()
         capabilities.declare(capabilities.Capability(
             name="library",
-            residency=capabilities.RESIDENCY_CATALOG,
+            residency=[capabilities.RESIDENCY_CATALOG],
             description="Table inventory",
         ))
         capabilities.declare(capabilities.Capability(
             name="peripherals",
-            residency=capabilities.RESIDENCY_PLAY_HOST,
+            residency=[capabilities.RESIDENCY_PLAY_HOST],
             is_available=lambda: (False, "No DOF hardware detected"),
         ))
 
@@ -70,11 +70,34 @@ class DiscoveryTests(unittest.TestCase):
         self.assertEqual(names, sorted(names), "sorted by name for a stable payload")
 
         by_name = {c["name"]: c for c in declared}
-        self.assertEqual(by_name["library"]["residency"], "catalog")
+        self.assertEqual(by_name["library"]["residency"], ["catalog"])
         self.assertTrue(by_name["library"]["available"])
         self.assertIsNone(by_name["library"]["reason"])
         self.assertFalse(by_name["peripherals"]["available"])
         self.assertEqual(by_name["peripherals"]["reason"], "No DOF hardware detected")
+
+    def test_a_capability_can_live_in_both_roles(self) -> None:
+        """Both means each role serves its own, not that one spans the two."""
+        self._isolated()
+        capabilities.declare(capabilities.Capability(
+            name="events",
+            residency=[capabilities.RESIDENCY_CATALOG, capabilities.RESIDENCY_PLAY_HOST],
+        ))
+
+        declared = self.client.get("/").json()["capabilities"]
+
+        self.assertEqual(declared[0]["residency"], ["catalog", "play_host"])
+
+    def test_a_bare_string_residency_is_refused(self) -> None:
+        """It would iterate into single characters and reach discovery as seven of them."""
+        with self.assertRaises(ValueError):
+            capabilities.Capability(name="library", residency=capabilities.RESIDENCY_CATALOG)
+
+    def test_an_unknown_or_empty_residency_is_refused(self) -> None:
+        with self.assertRaises(ValueError):
+            capabilities.Capability(name="library", residency=["somewhere-else"])
+        with self.assertRaises(ValueError):
+            capabilities.Capability(name="library", residency=[])
 
     def test_a_broken_availability_probe_does_not_break_discovery(self) -> None:
         def _explode():
@@ -82,7 +105,7 @@ class DiscoveryTests(unittest.TestCase):
 
         self._isolated()
         capabilities.declare(capabilities.Capability(
-            name="flaky", residency=capabilities.RESIDENCY_PLAY_HOST, is_available=_explode))
+            name="flaky", residency=[capabilities.RESIDENCY_PLAY_HOST], is_available=_explode))
 
         response = self.client.get("/")
         declared = response.json()["capabilities"]


### PR DESCRIPTION
Some capabilities belong to both roles and there was no way to say so. The event stream is the case that forced it: it carries library events and launch events alike.

Listing both means each role serves its own, not that one capability spans the two. Split the catalog and the play host onto separate machines and they each have an event stream carrying their own events — a single value can't express that, and a "both" token would just make every client special-case it.

Discovery now reports `"residency": ["catalog"]` where it reported `"residency": "catalog"`. Clients test a role with `"play_host" in residency`, which reads the same whether a capability has one role or two.

A `Capability` now refuses a bare string. It would have iterated into single characters and reached discovery as seven residencies without complaining. Unknown and empty values are refused the same way — at the declaration rather than in the payload.

Nothing outside the repo reads this yet, which is why now is the time.