### PR TITLE
Ignore per-developer tool config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@ third-party/
 # PyInstaller build directories
 build/
 dist/
+
+# Per-developer assistant and editor config, never the project's
+.claude/
+.codex
+*.local.md


### PR DESCRIPTION
`.codex` was an empty file that got swept into a commit a while back and nothing ever
referenced it. Removed.

The ignore entries keep local assistant and editor config out of the tree so the same
thing can't happen again:

    .claude/
    .codex
    *.local.md

Worth landing before the other two branches. Without it a branch cut from master doesn't
ignore these, and a `git add -A` picks up whatever a contributor happens to keep locally.
