### PR TITLE
Restore .info files that a newer VPinFE upgraded

### DIFF
--- a/clioptions.py
+++ b/clioptions.py
@@ -7,7 +7,7 @@ from screeninfo import get_monitors
 from common.iniconfig import IniConfig
 from common.logging_config import get_logger
 from common.paths import VPINFE_INI_PATH, ensure_config_dir
-from common import metadata_service, table_report_service
+from common import info_restore, metadata_service, table_report_service
 from frontend.customhttpserver import CustomHTTPServer
 
 logger = get_logger("vpinfe.cli")
@@ -28,6 +28,14 @@ def buildMetaData(downloadMedia: bool = True, updateAll: bool = True, tableName:
         log_cb=log_cb,
         iniconfig=iniconfig,
     )
+
+
+def restore_info_files(table_name: str = None, progress_cb=None, log_cb=None):
+    from common.config_access import SettingsConfig
+
+    return info_restore.restore_library(
+        SettingsConfig.from_config(iniconfig).table_root_dir,
+        table_name=table_name, progress_cb=progress_cb, log_cb=log_cb)
 
 
 def listMissingTables():
@@ -110,7 +118,8 @@ def parseArgs():
     parser.add_argument("--no-media", action="store_true", help="Do not download images when building meta.ini")
     parser.add_argument("--update-all", action="store_true", help="Reparse all tables when building meta.ini")
     parser.add_argument("--user-media", action="store_true", help="With --buildmeta: skip vpinmediadb downloads and claim existing local media as user-sourced")
-    parser.add_argument("--table", help="Specify a single table folder name to process with --buildmeta or --claim-user-media")
+    parser.add_argument("--restore-info", action="store_true", help="Put back the .info files a newer VPinFE saved before converting them, for every table that has one. Your current .info is kept first")
+    parser.add_argument("--table", help="Specify a single table folder name to process with --buildmeta, --claim-user-media or --restore-info")
 
     args, unknown = parser.parse_known_args()  # macOS-friendly parsing
 
@@ -155,6 +164,10 @@ def parseArgs():
 
     if args.claim_user_media:
         claimUserMedia(tableName=args.table)
+        sys.exit()
+
+    if args.restore_info:
+        restore_info_files(table_name=args.table)
         sys.exit()
 
     if args.buildmeta:

--- a/common/info_restore.py
+++ b/common/info_restore.py
@@ -21,10 +21,12 @@ the user never chose which ones converted and cannot be asked to choose which co
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import os
 import shutil
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -87,6 +89,47 @@ def copy_aside(info_path, when=None):
         path = backup_path(info_path, when)
     shutil.copy2(info_path, path)
     return path
+
+
+def replace_atomic(source, path):
+    """Put `source` in place at `path` with no window where `path` is half written.
+
+    A plain copy over the live file truncates it first. Restoring does that once per
+    table across the whole library, and it is the operation somebody reaches for when
+    things have already gone wrong - the worst one to leave a truncated file behind.
+    """
+    directory = os.path.dirname(path) or "."
+    handle_fd, tmp = tempfile.mkstemp(dir=directory, prefix=".vpinfe_write_", suffix=".tmp")
+    os.close(handle_fd)
+    try:
+        shutil.copy2(source, tmp)
+        os.replace(tmp, path)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp)
+        raise
+
+
+def write_json_atomic(path, data):
+    """Write a .info so a reader sees either the old file or the new one, never half of one.
+
+    A plain open(path, "w") truncates before it writes, so an interrupted write leaves a
+    truncated file - and an unreadable .info is the one failure the library cannot shrug
+    off.
+    """
+    directory = os.path.dirname(path) or "."
+    # Must not look like a .info or a backup to anything scanning the folder.
+    handle_fd, tmp = tempfile.mkstemp(dir=directory, prefix=".vpinfe_write_", suffix=".tmp")
+    try:
+        with os.fdopen(handle_fd, "w", encoding="utf-8") as handle:
+            json.dump(data, handle, indent=4)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp, path)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp)
+        raise
 
 
 def table_dirs(table_root, table_name=None):
@@ -165,7 +208,7 @@ def restore_library(table_root, table_name=None, progress_cb=None, log_cb=None):
         try:
             if info_path.exists():
                 copy_aside(str(info_path))
-            shutil.copy2(chosen, info_path)
+            replace_atomic(chosen, info_path)
         except OSError as exc:
             result["failed"] += 1
             result["failures"].append((table_dir.name, str(exc)))

--- a/common/info_restore.py
+++ b/common/info_restore.py
@@ -1,0 +1,201 @@
+"""Put back a `.info` file that a newer VPinFE converted.
+
+A newer release rewrites each table's `.info` into a shape this one does not understand,
+and keeps the original beside it first. That copy is useless unless the release somebody
+downgrades *to* can find it - which is this module, and why it ships here rather than
+there.
+
+The filename convention is a contract between two releases and neither side may change it
+alone:
+
+    Attack from Mars (Bally 1995).info                            <- live
+    Attack from Mars (Bally 1995).info.vpinfe-20260729T143022Z    <- saved copy
+
+Which shape a saved copy holds is read out of its content, never its name. A file with no
+`schema` key predates versioning and is one this build wrote; anything carrying one was
+written by a newer build and is left alone.
+
+Restoring is library-wide on purpose. Conversion happens per table as tables get used, so
+the user never chose which ones converted and cannot be asked to choose which come back.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+
+logger = logging.getLogger("vpinfe.common.info_restore")
+
+BACKUP_MARKER = ".vpinfe-"
+
+
+def converted_by_newer(meta):
+    """Whether this table's live .info was written by a newer VPinFE.
+
+    The signal the offer to restore hangs on. Saved copies alone are not it: after a
+    restore they are still lying in the folder, and offering to put back a file that is
+    already in place reads as though the restore did not work.
+    """
+    if not isinstance(meta, dict):
+        return False
+    section = meta.get("vpinfe")
+    return isinstance(section, dict) and bool(section.get("schema"))
+
+
+def backup_names(names, info_name):
+    """The saved copies in a folder listing, newest first.
+
+    Takes names rather than a path so this can ride a scan the caller is already doing: on
+    a network share the listing is the expensive part. The timestamp is ISO 8601 basic, so
+    lexical order is chronological.
+    """
+    prefix = info_name + BACKUP_MARKER
+    return sorted((n for n in names if n.startswith(prefix)), reverse=True)
+
+
+def backup_schema(path):
+    """The schema a saved copy declares, or None when it predates versioning."""
+    with open(path, encoding="utf-8") as handle:
+        data = json.load(handle)
+    section = data.get("vpinfe") if isinstance(data, dict) else None
+    if not isinstance(section, dict):
+        return None
+    return int(section.get("schema") or 0) or None
+
+
+def backup_path(info_path, when=None):
+    """Where a saved copy goes. UTC and no colons, because Windows will not have them."""
+    stamp = (when or datetime.now(timezone.utc)).strftime("%Y%m%dT%H%M%SZ")
+    return f"{info_path}{BACKUP_MARKER}{stamp}"
+
+
+def copy_aside(info_path, when=None):
+    """Keep the current file before a restore replaces it, whatever state it is in.
+
+    Deliberately does not check that it parses. A file too broken to read is a file
+    somebody is restoring *because* it is broken, and refusing to keep it would block the
+    rescue to protect a copy nobody wants back.
+    """
+    path = backup_path(info_path, when)
+    while os.path.exists(path):        # never overwrite a restore point
+        when = when or datetime.now(timezone.utc)
+        when = when.replace(second=(when.second + 1) % 60)
+        path = backup_path(info_path, when)
+    shutil.copy2(info_path, path)
+    return path
+
+
+def table_dirs(table_root, table_name=None):
+    """Table folders under the root, in name order."""
+    root = Path(table_root)
+    if not root.is_dir():
+        return []
+    if table_name:
+        one = root / table_name
+        return [one] if one.is_dir() else []
+    return sorted(
+        (d for d in root.iterdir() if d.is_dir() and not d.name.startswith(".")),
+        key=lambda d: d.name.lower(),
+    )
+
+
+def restorable_backup(table_dir, names=None):
+    """The saved copy this build would put back in this folder, or None.
+
+    Newest first, and the first one this build can actually read wins. A copy written by a
+    newer VPinFE is stepped over rather than treated as the end of the list - the one
+    behind it is usually exactly what is wanted.
+
+    Reads each candidate, so callers pass `names` when they have already listed the folder.
+    Only folders holding a saved copy pay for it, which for anyone who never ran a newer
+    VPinFE is none of them.
+    """
+    table_dir = Path(table_dir)
+    if names is None:
+        try:
+            names = os.listdir(table_dir)
+        except OSError:
+            return None
+    info_name = f"{table_dir.name}.info"
+    for name in backup_names(names, info_name):
+        candidate = table_dir / name
+        try:
+            schema = backup_schema(candidate)
+        except (OSError, ValueError):
+            logger.warning("Unreadable saved copy, skipping: %s", candidate)
+            continue
+        if schema is None:
+            return str(candidate)
+    return None
+
+
+def restore_library(table_root, table_name=None, progress_cb=None, log_cb=None):
+    """Put back the newest readable copy in every folder that has one.
+
+    Never stops on one bad folder: an unreadable file is the state somebody is trying to
+    get out of, and failing the run would withhold the fix from every other table.
+    """
+    def log(message):
+        logger.info(message)
+        if log_cb:
+            log_cb(message)
+
+    folders = table_dirs(table_root, table_name)
+    total = len(folders)
+    result = {"restored": 0, "nothing_to_restore": 0, "failed": 0, "failures": []}
+
+    log("Restoring table info from the copies saved before a newer VPinFE converted it. "
+        "Your current info is kept first, so this can be undone too.")
+
+    for index, table_dir in enumerate(folders, start=1):
+        if progress_cb:
+            try:
+                progress_cb(index, total, table_dir.name)
+            except Exception:
+                logger.debug("Progress callback failed", exc_info=True)
+        chosen = restorable_backup(table_dir)
+        if not chosen:
+            result["nothing_to_restore"] += 1
+            continue
+        info_path = table_dir / f"{table_dir.name}.info"
+        try:
+            if info_path.exists():
+                copy_aside(str(info_path))
+            shutil.copy2(chosen, info_path)
+        except OSError as exc:
+            result["failed"] += 1
+            result["failures"].append((table_dir.name, str(exc)))
+            log(f"Left as it is, could not be restored: {table_dir.name}")
+            continue
+        result["restored"] += 1
+        log(f"Restored: {table_dir.name}")
+
+    log(_summary(result))
+    return result
+
+
+def _tables(count):
+    return f"{count} table" if count == 1 else f"{count} tables"
+
+
+def _summary(result):
+    if not result["restored"]:
+        return "Nothing to restore - no table has info saved by a newer VPinFE."
+    summary = (
+        f"Restored {_tables(result['restored'])}. Their ratings, favourites, tags and play "
+        "counts are back as this version recorded them."
+    )
+    if result["nothing_to_restore"]:
+        summary += (
+            f" {_tables(result['nothing_to_restore'])} were never converted, so there was "
+            "nothing to put back."
+        )
+    if result["failed"]:
+        summary += (
+            f" {_tables(result['failed'])} could not be restored and were left as they are."
+        )
+    return summary

--- a/common/metaconfig.py
+++ b/common/metaconfig.py
@@ -1,6 +1,7 @@
 import json
 import os
 from urllib.parse import urlparse, parse_qs
+from common.info_restore import write_json_atomic
 
 
 class InvalidMetaConfigError(ValueError):
@@ -146,8 +147,7 @@ class MetaConfig:
     def writeConfig(self):
         self._normalize_detection_flags()
         os.makedirs(os.path.dirname(self.configFilePath), exist_ok=True)
-        with open(self.configFilePath, "w", encoding="utf-8") as f:
-            json.dump(self.data, f, indent=4)
+        write_json_atomic(self.configFilePath, self.data)
 
     def getConfig(self):
         return self.data

--- a/common/table.py
+++ b/common/table.py
@@ -42,3 +42,5 @@ class Table:
     # After a restore the folder still holds the ones it could not use, and counting those
     # would leave the offer on screen with nothing behind it.
     info_restorable: bool = False
+    # Newest backup's timestamp, so the restore dialog can name the day it goes back to.
+    info_backup_stamp: str = ""

--- a/common/table.py
+++ b/common/table.py
@@ -34,3 +34,11 @@ class Table:
     AudioPath: str | None = None
 
     metaConfig: dict[str, Any] | None = None
+
+    # Read during the scan because the scan already listed the folder. Asking again later
+    # costs a second walk of the library, which on a network share is the whole cost.
+    #
+    # Restorable means a saved copy this build can actually read, not merely a saved copy.
+    # After a restore the folder still holds the ones it could not use, and counting those
+    # would leave the offer on screen with nothing behind it.
+    info_restorable: bool = False

--- a/common/table_repository.py
+++ b/common/table_repository.py
@@ -44,6 +44,15 @@ def refresh_tables() -> List[Any]:
     return ensure_tables_loaded(reload=True)
 
 
+def unreadable_tables() -> List[Dict[str, str]]:
+    """Folders whose .info could not be read, so the table was left out of the library."""
+    ensure_tables_loaded()
+    with _LOCK:
+        if _PARSER is None:
+            return []
+        return [dict(row) for row in _PARSER.getUnreadableTables()]
+
+
 def restorable_table_names() -> List[str]:
     """Folders holding a .info saved by a newer VPinFE, so the Tables page can offer to
     put them back. Read off the loaded library, which listed every folder to get there."""

--- a/common/table_repository.py
+++ b/common/table_repository.py
@@ -44,6 +44,15 @@ def refresh_tables() -> List[Any]:
     return ensure_tables_loaded(reload=True)
 
 
+def restorable_table_names() -> List[str]:
+    """Folders holding a .info saved by a newer VPinFE, so the Tables page can offer to
+    put them back. Read off the loaded library, which listed every folder to get there."""
+    return sorted(
+        (t.tableDirName for t in ensure_tables_loaded() if getattr(t, "info_restorable", False)),
+        key=str.lower,
+    )
+
+
 def refresh_table(table_path: str) -> List[Any]:
     normalized = str(Path(table_path).expanduser().resolve())
     tables = refresh_tables()

--- a/common/table_repository.py
+++ b/common/table_repository.py
@@ -53,6 +53,13 @@ def unreadable_tables() -> List[Dict[str, str]]:
         return [dict(row) for row in _PARSER.getUnreadableTables()]
 
 
+def newest_backup_stamp() -> str:
+    """The most recent backup timestamp in the library, or ""."""
+    stamps = [s for s in (getattr(t, "info_backup_stamp", "")
+                          for t in ensure_tables_loaded()) if s]
+    return max(stamps) if stamps else ""
+
+
 def restorable_table_names() -> List[str]:
     """Folders holding a .info saved by a newer VPinFE, so the Tables page can offer to
     put them back. Read off the loaded library, which listed every folder to get there."""

--- a/common/tableparser.py
+++ b/common/tableparser.py
@@ -22,6 +22,7 @@ class TableParser:
         self.tabletype = "table"
         self.tables: list[Table] = []
         self.missing_tables: list[dict] = []
+        self.unreadable_tables: list[dict] = []
         if iniConfig:
             self.tabletype = MediaConfig.from_config(iniConfig).table_type
         self.loadTables()
@@ -33,6 +34,7 @@ class TableParser:
         started_at = perf_counter()
         self.tables.clear()
         self.missing_tables.clear()
+        self.unreadable_tables.clear()
 
         if not self.tablesRootFilePath.exists():
             return
@@ -94,10 +96,23 @@ class TableParser:
                 table_contents=table_contents,
                 has_medias_dir="medias" in table_subdirs,
             )
-            self.loadMetaData(table)
+            try:
+                self.loadMetaData(table)
+            except InvalidMetaConfigError as exc:
+                # One unreadable file used to stop the whole library loading, so a single
+                # truncated .info left the app with no tables at all. Drop the one table
+                # and keep going: excluded rather than loaded empty, because loading it
+                # empty would let the next write overwrite a file we could not read.
+                self.unreadable_tables.append({
+                    'folder': table.tableDirName,
+                    'path': str(table_dir),
+                    'error': str(exc),
+                })
+                logger.error("Skipping table with unreadable metadata: %s", exc)
+                continue
 
-            # Only a table a newer VPinFE actually converted has anything to put back,
-            # and only then is a saved copy worth opening to check we can read it.
+            # Only a table a newer VPinFE upgraded has anything to put back, and only then
+            # is a saved copy worth opening to check we can read it.
             table.info_restorable = bool(
                 converted_by_newer(table.metaConfig)
                 and backup_names(table_contents, info_name)
@@ -147,6 +162,10 @@ class TableParser:
 
     def getAllTables(self):
         return list(self.tables)
+
+    def getUnreadableTables(self):
+        """Folders whose .info could not be read, so the table was left out."""
+        return [dict(row) for row in self.unreadable_tables]
 
     def getMissingTables(self):
         return [dict(row) for row in self.missing_tables]

--- a/common/tableparser.py
+++ b/common/tableparser.py
@@ -5,6 +5,7 @@ from time import perf_counter
 from common.config_access import MediaConfig
 from common.media_paths import apply_media_paths
 from common.table import Table
+from common.info_restore import backup_names, converted_by_newer, restorable_backup
 from common.metaconfig import InvalidMetaConfigError, MetaConfig
 
 
@@ -94,6 +95,13 @@ class TableParser:
                 has_medias_dir="medias" in table_subdirs,
             )
             self.loadMetaData(table)
+
+            # Only a table a newer VPinFE actually converted has anything to put back,
+            # and only then is a saved copy worth opening to check we can read it.
+            table.info_restorable = bool(
+                converted_by_newer(table.metaConfig)
+                and backup_names(table_contents, info_name)
+                and restorable_backup(table_dir, names=table_contents))
 
             self.tables.append(table)
 

--- a/common/tableparser.py
+++ b/common/tableparser.py
@@ -5,7 +5,12 @@ from time import perf_counter
 from common.config_access import MediaConfig
 from common.media_paths import apply_media_paths
 from common.table import Table
-from common.info_restore import backup_names, converted_by_newer, restorable_backup
+from common.info_restore import (
+    BACKUP_MARKER,
+    backup_names,
+    converted_by_newer,
+    restorable_backup,
+)
 from common.metaconfig import InvalidMetaConfigError, MetaConfig
 
 
@@ -113,10 +118,13 @@ class TableParser:
 
             # Only a table a newer VPinFE upgraded has anything to put back, and only then
             # is a saved copy worth opening to check we can read it.
+            stamps = backup_names(table_contents, info_name)
             table.info_restorable = bool(
                 converted_by_newer(table.metaConfig)
-                and backup_names(table_contents, info_name)
+                and stamps
                 and restorable_backup(table_dir, names=table_contents))
+            if stamps:
+                table.info_backup_stamp = stamps[0].rsplit(BACKUP_MARKER, 1)[-1]
 
             self.tables.append(table)
 

--- a/managerui/pages/info_restore_dialog.py
+++ b/managerui/pages/info_restore_dialog.py
@@ -1,0 +1,168 @@
+"""Offering to put back .info files that a newer VPinFE converted.
+
+Somebody who lands here has usually just gone back to this version because a newer one
+did not work out for them. Requiring them to know this feature exists is requiring the
+wrong thing at the worst moment, so the banner looks for the situation and offers the fix
+without being asked. It renders only when there is something to put back, which for
+anyone who never ran a newer VPinFE is never.
+
+All or nothing across the library: conversion happened per table as tables were used, so
+the user never chose which ones converted and cannot be asked to choose which come back.
+The list is there to answer "what will this touch", not to be picked from.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from queue import Queue
+
+from nicegui import run, ui
+
+from managerui.services import table_service
+from managerui.ui_helpers import dialog_card
+
+logger = logging.getLogger("vpinfe.manager.info_restore")
+
+_ACCENT = ('color: var(--neon-cyan) !important; background: var(--surface) !important; '
+           'border: 1px solid var(--neon-cyan); border-radius: 18px; padding: 4px 10px;')
+_MUTED = ('color: var(--ink-muted) !important; background: var(--surface) !important; '
+          'border: 1px solid var(--line); border-radius: 18px; padding: 4px 10px;')
+
+INTRO = (
+    "Puts back the .info file each table had before a newer VPinFE converted it. Your "
+    "ratings, favourites, tags and play counts go back to what this version recorded."
+)
+
+DETAIL = (
+    "The file being replaced is saved alongside it first, so this can be undone. Tables "
+    "that were never converted are left exactly as they are."
+)
+
+
+def _restorable_names():
+    try:
+        return table_service.restorable_table_names()
+    except Exception:
+        logger.exception("Could not list tables with a saved .info")
+        return []
+
+
+def open_restore_dialog(on_done=None) -> None:
+    names = _restorable_names()
+    if not names:
+        ui.notify("No table has an older .info saved, so there is nothing to put back.",
+                  type='info')
+        return
+
+    dlg = ui.dialog().props('persistent max-width=700px')
+    state = {'running': False, 'lines': [], 'progress_q': Queue(), 'log_q': Queue()}
+
+    with dlg, dialog_card("650px"):
+        ui.label('Restore table info').classes('text-xl font-bold').style('color: var(--ink);')
+        ui.separator()
+
+        intro_container = ui.column().classes('gap-3 q-my-md w-full')
+        with intro_container:
+            ui.label(INTRO).classes('text-sm').style('color: var(--ink);')
+            ui.label(DETAIL).classes('text-xs').style('color: var(--ink-muted);')
+            with ui.expansion(f'Show the {len(names)} tables').classes('w-full'):
+                with ui.column().classes('w-full p-2').style(
+                        'max-height: 14rem; overflow: auto;'):
+                    for name in names:
+                        ui.label(name).classes('text-xs').style('color: var(--ink-muted);')
+
+        progress_container = ui.column().classes('w-full gap-2')
+        progress_container.visible = False
+        with progress_container:
+            progressbar = ui.linear_progress(value=0.0, show_value=False).classes('w-full')
+            status_label = ui.label("Preparing...").classes("text-sm").style('color: var(--ink);')
+            log_container = ui.column().classes("w-full p-3 overflow-auto").style(
+                "max-height: 250px; font-family: monospace; font-size: 11px; "
+                "color: var(--ink); background: var(--surface); "
+                "border: 1px solid var(--neon-purple); border-radius: var(--radius);")
+
+        with ui.row().classes('justify-end gap-2 q-mt-md w-full'):
+            cancel_btn = ui.button('Cancel', on_click=dlg.close).style(_MUTED)
+            start_btn = ui.button('Restore all', icon='history').style(_ACCENT)
+            close_btn = ui.button('Close', on_click=dlg.close).style(_MUTED)
+            close_btn.visible = False
+
+        def pump():
+            updated = False
+            while not state['progress_q'].empty():
+                updated = True
+                current, total, message = state['progress_q'].get_nowait()
+                if total:
+                    progressbar.value = max(0.0, min(1.0, current / total))
+                    status_label.text = f'{message} — {current}/{total}'
+                else:
+                    status_label.text = message or ''
+            while not state['log_q'].empty():
+                state['lines'].append(state['log_q'].get_nowait())
+                if len(state['lines']) > 100:
+                    state['lines'].pop(0)
+                updated = True
+            if updated:
+                log_container.clear()
+                with log_container:
+                    for line in state['lines']:
+                        ui.label(line).classes("text-xs whitespace-pre-wrap").style(
+                            'color: var(--ink);')
+
+        timer = ui.timer(0.1, pump, active=False)
+
+        async def go():
+            if state['running']:
+                return
+            state['running'] = True
+            intro_container.visible = False
+            progress_container.visible = True
+            start_btn.visible = False
+            cancel_btn.visible = False
+            timer.active = True
+            try:
+                await run.io_bound(
+                    table_service.restore_info,
+                    progress_cb=lambda c, t, m: state['progress_q'].put((c, t, m)),
+                    log_cb=state['log_q'].put,
+                )
+                progressbar.value = 1.0
+                status_label.text = "Finished"
+            except Exception as exc:
+                logger.exception("Restore failed")
+                status_label.text = "Stopped"
+                state['log_q'].put(f"Stopped before finishing: {exc}")
+            finally:
+                pump()
+                timer.active = False
+                close_btn.visible = True
+                state['running'] = False
+                if on_done:
+                    on_done()
+
+        start_btn.on_click(lambda: asyncio.create_task(go()))
+
+    dlg.open()
+
+
+def render_restore_banner(on_done=None) -> None:
+    """Say something only when a newer VPinFE has been here."""
+    names = _restorable_names()
+    if not names:
+        return
+
+    tables = "1 table has" if len(names) == 1 else f"{len(names)} tables have"
+    with ui.card().classes('w-full mb-4').style(
+            'background: var(--surface-soft); border: 1px solid var(--line);'):
+        with ui.row().classes('w-full items-center justify-between gap-4 p-3 flex-wrap'):
+            with ui.row().classes('items-center gap-3'):
+                ui.icon('history', size='20px').style('color: var(--neon-cyan);')
+                with ui.column().classes('gap-1'):
+                    ui.label(f'{tables} info saved by a newer VPinFE.').classes(
+                        'text-sm').style('color: var(--ink);')
+                    ui.label('Restore to put back the version this release can read. Your '
+                             'current info is saved first.').classes('text-xs').style(
+                        'color: var(--ink-muted);')
+            ui.button('Restore', icon='history',
+                      on_click=lambda: open_restore_dialog(on_done)).style(_ACCENT)

--- a/managerui/pages/info_restore_dialog.py
+++ b/managerui/pages/info_restore_dialog.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from datetime import datetime
 from queue import Queue
 
 from nicegui import run, ui
@@ -30,14 +31,59 @@ _MUTED = ('color: var(--ink-muted) !important; background: var(--surface) !impor
           'border: 1px solid var(--line); border-radius: 18px; padding: 4px 10px;')
 
 INTRO = (
-    "Puts back the .info file each table had before a newer VPinFE converted it. Your "
-    "ratings, favourites, tags and play counts go back to what this version recorded."
+    "Puts your ratings, favourites, tags and play counts back to how they were{when}. "
+    "Your current .info files are backed up first."
 )
 
 DETAIL = (
-    "The file being replaced is saved alongside it first, so this can be undone. Tables "
-    "that were never converted are left exactly as they are."
+    "Tables a newer VPinFE never touched are left exactly as they are."
 )
+
+
+def _files(n):
+    return "1 .info file" if n == 1 else f"{n} .info files"
+
+
+def _backup_date(stamp):
+    """A backup timestamp as a plain date, or "" if it cannot be read.
+
+    Built without %-d, which is not portable to Windows.
+    """
+    try:
+        parsed = datetime.strptime(stamp, "%Y%m%dT%H%M%SZ")
+    except (TypeError, ValueError):
+        return ""
+    return parsed.strftime("%d %B %Y").lstrip("0")
+
+
+def _strip(icon, colour, headline, detail, actions):
+    """One row: icon, text, actions.
+
+    The text column needs `grow min-w-0` and the row `flex-nowrap`, or a long detail line
+    grows past the available width and pushes the icon onto a line of its own.
+    """
+    with ui.card().classes('w-full mb-3').style(
+            f'background: var(--surface-soft); border: 1px solid {colour};'):
+        with ui.row().classes('w-full items-center gap-4 px-4 py-3 flex-wrap md:flex-nowrap'):
+            ui.icon(icon, size='24px').classes('shrink-0').style(f'color: {colour};')
+            with ui.column().classes('gap-1 grow min-w-0'):
+                ui.label(headline).classes('text-sm font-medium').style('color: var(--ink);')
+                ui.label(detail).classes('text-xs').style('color: var(--ink-muted);')
+            with ui.row().classes('gap-2 items-center shrink-0'):
+                actions()
+
+
+def _refresh_banners():
+    """Re-render the strips after a restore, so the one that prompted it goes away."""
+    try:
+        render_restore_banner.refresh()
+    except Exception:
+        logger.debug("Banner refresh skipped", exc_info=True)
+
+
+def _when():
+    date = _backup_date(table_service.newest_backup_stamp())
+    return f" on {date}" if date else " before the upgrade"
 
 
 def _restorable_names():
@@ -51,20 +97,19 @@ def _restorable_names():
 def open_restore_dialog(on_done=None) -> None:
     names = _restorable_names()
     if not names:
-        ui.notify("No table has an older .info saved, so there is nothing to put back.",
-                  type='info')
+        ui.notify("There are no backups to restore.", type='info')
         return
 
     dlg = ui.dialog().props('persistent max-width=700px')
     state = {'running': False, 'lines': [], 'progress_q': Queue(), 'log_q': Queue()}
 
     with dlg, dialog_card("650px"):
-        ui.label('Restore table info').classes('text-xl font-bold').style('color: var(--ink);')
+        ui.label('Restore backups').classes('text-xl font-bold').style('color: var(--ink);')
         ui.separator()
 
         intro_container = ui.column().classes('gap-3 q-my-md w-full')
         with intro_container:
-            ui.label(INTRO).classes('text-sm').style('color: var(--ink);')
+            ui.label(INTRO.format(when=_when())).classes('text-sm').style('color: var(--ink);')
             ui.label(DETAIL).classes('text-xs').style('color: var(--ink-muted);')
             with ui.expansion(f'Show the {len(names)} tables').classes('w-full'):
                 with ui.column().classes('w-full p-2').style(
@@ -140,29 +185,49 @@ def open_restore_dialog(on_done=None) -> None:
                 state['running'] = False
                 if on_done:
                     on_done()
+                _refresh_banners()
 
         start_btn.on_click(lambda: asyncio.create_task(go()))
 
     dlg.open()
 
 
+@ui.refreshable
 def render_restore_banner(on_done=None) -> None:
     """Say something only when a newer VPinFE has been here."""
+    _render_unreadable_warning()
     names = _restorable_names()
     if not names:
         return
 
-    tables = "1 table has" if len(names) == 1 else f"{len(names)} tables have"
-    with ui.card().classes('w-full mb-4').style(
-            'background: var(--surface-soft); border: 1px solid var(--line);'):
-        with ui.row().classes('w-full items-center justify-between gap-4 p-3 flex-wrap'):
-            with ui.row().classes('items-center gap-3'):
-                ui.icon('history', size='20px').style('color: var(--neon-cyan);')
-                with ui.column().classes('gap-1'):
-                    ui.label(f'{tables} info saved by a newer VPinFE.').classes(
-                        'text-sm').style('color: var(--ink);')
-                    ui.label('Restore to put back the version this release can read. Your '
-                             'current info is saved first.').classes('text-xs').style(
-                        'color: var(--ink-muted);')
-            ui.button('Restore', icon='history',
-                      on_click=lambda: open_restore_dialog(on_done)).style(_ACCENT)
+    _strip(
+        'history', 'var(--neon-cyan)',
+        f'A newer VPinFE upgraded {_files(len(names))}.',
+        'Restore puts your ratings, favourites, tags and play counts back to how this '
+        'version recorded them, and backs up the current files first.',
+        lambda: ui.button('Restore backups', icon='history',
+                          on_click=lambda: open_restore_dialog(on_done)).style(_ACCENT),
+    )
+
+
+def _render_unreadable_warning() -> None:
+    """Not dismissible: the table is missing from the frontend until somebody deals with it."""
+    try:
+        broken = table_service.unreadable_tables()
+    except Exception:
+        logger.exception("Could not read the unreadable-table list")
+        return
+    if not broken:
+        return
+
+    shown = ", ".join(row.get("folder", "?") for row in broken[:3])
+    if len(broken) > 3:
+        shown += f" and {len(broken) - 3} more"
+    tables = "1 table is" if len(broken) == 1 else f"{len(broken)} tables are"
+    _strip(
+        'warning', 'var(--neon-pink)',
+        f'{tables} missing because the .info file could not be read.',
+        f'{shown}. The files were left untouched — a backup may hold a working copy.',
+        lambda: ui.button('Restore backups', icon='history',
+                          on_click=lambda: open_restore_dialog()).style(_ACCENT),
+    )

--- a/managerui/pages/tables.py
+++ b/managerui/pages/tables.py
@@ -12,6 +12,7 @@ from managerui.pages.table_detail_dialog import open_table_dialog
 from managerui.pages.table_import_dialog import open_import_table_dialog
 from managerui.pages.dnd_drop_zone import create_drop_zone, enable_row_drops, DropContext
 from managerui.pages.table_match_dialog import open_match_vps_dialog, open_missing_tables_dialog
+from managerui.pages.info_restore_dialog import render_restore_banner
 from managerui.services import table_service
 from managerui.services import table_index_service
 from managerui.services.media_service import invalidate_media_cache
@@ -600,6 +601,9 @@ def render_panel(tab=None):
                     import_btn = ui.button("Import Table", icon="upload").props("color=accent").style('border-radius: 0;')
 
                     import_btn.on_click(lambda: open_import_table_dialog(perform_scan))
+
+        # Only says anything when a newer VPinFE has converted tables in this library.
+        render_restore_banner(on_done=lambda: asyncio.create_task(perform_scan(silent=True)))
 
         def _dnd_context() -> DropContext:
             selected = table.selected or []

--- a/managerui/services/table_service.py
+++ b/managerui/services/table_service.py
@@ -407,6 +407,11 @@ def build_metadata(*args, **kwargs):
     return metadata_service.build_metadata(*args, iniconfig=_fresh_config(), **kwargs)
 
 
+def unreadable_tables():
+    """Tables the scan had to leave out because their .info could not be read."""
+    return table_repository.unreadable_tables()
+
+
 def restorable_table_names():
     """Folders with a .info saved by a newer VPinFE, for the banner and its dialog."""
     return table_repository.restorable_table_names()

--- a/managerui/services/table_service.py
+++ b/managerui/services/table_service.py
@@ -8,6 +8,7 @@ from typing import Dict, List, Optional
 
 from common.iniconfig import IniConfig
 from common.config_access import MediaConfig, SettingsConfig
+from common import info_restore, table_repository
 from common.table_repository import get_missing_tables, get_table_rows, refresh_table
 from common import metadata_service
 from common.vpxcollections import VPXCollections
@@ -404,6 +405,19 @@ def extract_vbs(table_path: str, vpx_filename: str, altlauncher: str = "") -> di
 
 def build_metadata(*args, **kwargs):
     return metadata_service.build_metadata(*args, iniconfig=_fresh_config(), **kwargs)
+
+
+def restorable_table_names():
+    """Folders with a .info saved by a newer VPinFE, for the banner and its dialog."""
+    return table_repository.restorable_table_names()
+
+
+def restore_info(progress_cb=None, log_cb=None, **kwargs):
+    """Put back the .info files a newer VPinFE converted, library-wide."""
+    result = info_restore.restore_library(
+        get_tables_path(), progress_cb=progress_cb, log_cb=log_cb, **kwargs)
+    table_repository.refresh_tables()
+    return result
 
 
 def apply_vpx_patches(*args, **kwargs):

--- a/managerui/services/table_service.py
+++ b/managerui/services/table_service.py
@@ -412,6 +412,11 @@ def unreadable_tables():
     return table_repository.unreadable_tables()
 
 
+def newest_backup_stamp():
+    """Timestamp of the most recent backup, for naming the date a restore goes back to."""
+    return table_repository.newest_backup_stamp()
+
+
 def restorable_table_names():
     """Folders with a .info saved by a newer VPinFE, for the banner and its dialog."""
     return table_repository.restorable_table_names()

--- a/tests/test_info_restore.py
+++ b/tests/test_info_restore.py
@@ -1,0 +1,197 @@
+"""Putting back a .info that a newer VPinFE converted.
+
+This runs in the release somebody downgrades *to*, so the cases that matter are the ones
+where the newer build left something this one has never seen.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from common.info_restore import (
+    backup_names,
+    backup_path,
+    converted_by_newer,
+    restorable_backup,
+    restore_library,
+    table_dirs,
+)
+
+OURS = {
+    "Info": {"Title": "Dr. Dude", "Rom": "dd_l2"},
+    "User": {"Rating": 4, "StartCount": 12, "Tags": ["fast"]},
+    "VPXFile": {"filename": "Dr. Dude.vpx", "filehash": "abc123"},
+    "Medias": {"wheel": {"Source": "user"}},
+}
+
+CONVERTED = {
+    "Info": {"Title": "Dr. Dude"},
+    "User": {"Rating": 4, "StartCount": 12, "Tags": ["fast"]},
+    "vpinfe": {"schema": 2, "id": "mJ8F4RqD8U"},
+    "game_files": {"Dr. Dude.vpx": {"file_hash": "abc123"}},
+}
+
+
+class RestoreTestCase(unittest.TestCase):
+    def setUp(self):
+        self._tmp = TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name)
+
+    def _converted_table(self, name="Dr. Dude", saved=OURS, live=CONVERTED):
+        """A folder as a newer VPinFE leaves it: converted .info, original kept beside it."""
+        table_dir = self.root / name
+        table_dir.mkdir()
+        (table_dir / f"{name}.vpx").write_text("not really a vpx", encoding="utf-8")
+        (table_dir / f"{name}.info").write_text(json.dumps(live), encoding="utf-8")
+        stamp = f"{name}.info.vpinfe-20260729T143022Z"
+        (table_dir / stamp).write_text(json.dumps(saved), encoding="utf-8")
+        return table_dir
+
+    def _info(self, table_dir):
+        return json.loads(
+            (table_dir / f"{table_dir.name}.info").read_text(encoding="utf-8"))
+
+    def _backups(self, table_dir):
+        return sorted(p for p in table_dir.iterdir() if ".vpinfe-" in p.name)
+
+
+class RestoreTests(RestoreTestCase):
+    def test_it_puts_back_what_this_version_wrote(self):
+        table = self._converted_table()
+
+        result = restore_library(self.root)
+
+        self.assertEqual(result["restored"], 1)
+        after = self._info(table)
+        self.assertEqual(after["VPXFile"]["filehash"], "abc123")
+        self.assertEqual(after["User"]["Rating"], 4)
+        self.assertNotIn("vpinfe", after)
+
+    def test_a_table_a_newer_build_never_touched_is_left_alone(self):
+        table_dir = self.root / "Taxi"
+        table_dir.mkdir()
+        (table_dir / "Taxi.vpx").write_text("x", encoding="utf-8")
+        (table_dir / "Taxi.info").write_text(json.dumps(OURS), encoding="utf-8")
+
+        result = restore_library(self.root)
+
+        self.assertEqual(result["restored"], 0)
+        self.assertEqual(result["nothing_to_restore"], 1)
+
+    def test_the_converted_file_is_kept_so_the_restore_is_reversible(self):
+        table = self._converted_table()
+
+        restore_library(self.root)
+
+        kept = [json.loads(p.read_text(encoding="utf-8")) for p in self._backups(table)]
+        self.assertIn(CONVERTED, kept)
+
+    def test_a_copy_this_version_cannot_read_is_never_restored(self):
+        """The rule that makes the whole thing safe: a schema 2 file put back here would
+        leave the user on a shape this build has never understood."""
+        table = self._converted_table(saved=CONVERTED)
+
+        result = restore_library(self.root)
+
+        self.assertEqual(result["restored"], 0)
+        self.assertIsNone(restorable_backup(table))
+
+    def test_a_newer_copy_is_stepped_over_to_reach_one_we_can_read(self):
+        table = self._converted_table()
+        (table / "Dr. Dude.info.vpinfe-20990101T000000Z").write_text(
+            json.dumps(CONVERTED), encoding="utf-8")
+
+        restore_library(self.root)
+
+        self.assertEqual(self._info(table)["VPXFile"]["filehash"], "abc123")
+
+    def test_an_unreadable_copy_is_skipped_rather_than_restored(self):
+        table = self._converted_table()
+        (table / "Dr. Dude.info.vpinfe-20990101T000000Z").write_text("{ broken", "utf-8")
+
+        result = restore_library(self.root)
+
+        self.assertEqual(result["restored"], 1)
+        self.assertEqual(self._info(table)["User"]["Rating"], 4)
+
+    def test_a_corrupt_current_file_is_still_kept_before_being_replaced(self):
+        """The file most likely to need restoring is the one too broken to parse."""
+        table = self._converted_table()
+        (table / "Dr. Dude.info").write_text("{ truncated", encoding="utf-8")
+
+        result = restore_library(self.root)
+
+        self.assertEqual(result["restored"], 1)
+        kept = [p.read_text(encoding="utf-8") for p in self._backups(table)]
+        self.assertIn("{ truncated", kept)
+
+    def test_one_bad_folder_does_not_stop_the_others(self):
+        self._converted_table("Dr. Dude")
+        self._converted_table("Taxi")
+
+        result = restore_library(self.root)
+
+        self.assertEqual(result["restored"], 2)
+        self.assertEqual(result["failed"], 0)
+
+    def test_one_table_can_be_restored_on_its_own(self):
+        self._converted_table("Dr. Dude")
+        other = self._converted_table("Taxi")
+
+        result = restore_library(self.root, table_name="Dr. Dude")
+
+        self.assertEqual(result["restored"], 1)
+        self.assertIn("vpinfe", self._info(other))
+
+
+class OfferTests(RestoreTestCase):
+    """What decides whether the Tables page offers a restore at all."""
+
+    def test_a_converted_table_is_worth_offering(self):
+        self.assertTrue(converted_by_newer(CONVERTED))
+
+    def test_a_table_this_version_wrote_is_not(self):
+        self.assertFalse(converted_by_newer(OURS))
+
+    def test_leftover_saved_copies_alone_do_not_keep_the_offer_alive(self):
+        """After a restore the folder still holds the copies, but the live file is ours
+        again. Offering to put back a file that is already in place reads as though the
+        restore did not work."""
+        table = self._converted_table()
+        restore_library(self.root)
+
+        self.assertFalse(converted_by_newer(self._info(table)))
+        self.assertTrue(self._backups(table), "the copies are still there")
+
+
+class NamingTests(RestoreTestCase):
+    def test_the_name_matches_what_the_newer_release_writes(self):
+        """A contract between two releases: neither side may change it alone."""
+        from datetime import datetime, timezone
+
+        stamp = datetime(2026, 7, 29, 14, 30, 22, tzinfo=timezone.utc)
+
+        self.assertEqual(backup_path("/tables/X/X.info", stamp),
+                         "/tables/X/X.info.vpinfe-20260729T143022Z")
+
+    def test_saved_copies_are_listed_newest_first(self):
+        names = {"X.info", "X.info.vpinfe-20260101T000000Z",
+                 "X.info.vpinfe-20260729T143022Z", "X.vpx"}
+
+        self.assertEqual(backup_names(names, "X.info"),
+                         ["X.info.vpinfe-20260729T143022Z",
+                          "X.info.vpinfe-20260101T000000Z"])
+
+    def test_dot_folders_are_not_tables(self):
+        (self.root / ".hidden").mkdir()
+        self._converted_table("Dr. Dude")
+
+        self.assertEqual([d.name for d in table_dirs(self.root)], ["Dr. Dude"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
3.0 rewrites every table's `.info` into a new shape and keeps a copy of the original
first. That copy is useless unless the release somebody downgrades *to* can find it, so
this has to ship here, before 3.0 goes out.

`--restore-info` walks the table root and puts back the newest saved copy this build can
read. Anything carrying a `schema` key was written by a newer VPinFE and is stepped over;
copies behind it are still offered, so a newer one isn't a dead end. Library-wide, because
the upgrade is library-wide: nobody chose which tables were upgraded, so nobody can be
asked to choose which come back. The file being replaced is kept first, so this is
reversible too.

The Manager UI looks for the situation rather than waiting to be asked. Somebody who needs
this has usually just gone back to this release because a newer one didn't work out for
them, and expecting them to know a command exists is expecting the wrong thing at the worst
moment. A strip appears on the Tables page when a table's live `.info` was written by a
newer VPinFE and there's a copy this build can read. For anyone who never ran a newer
VPinFE it never appears.

Two fixes came out of building it that stand on their own:

- `.info` writes go through a temp file and a rename. `open(path, "w")` truncates before it
  writes and `shutil.copy2` over the live file does the same, so an interrupted write left
  a truncated file. A restore does that once per table across the whole library.
- One unreadable `.info` used to stop the entire library loading, so a single truncated
  file left the app with no tables at all. That table is excluded and named now, and its
  file is left untouched rather than loaded empty.

The backup filename, and reading the shape out of the file rather than its name, are a
contract with 3.0. Neither side can change them alone.
