### PR TITLE
Keep backup names in the order they were written

### DIFF
--- a/common/info_restore.py
+++ b/common/info_restore.py
@@ -27,7 +27,7 @@ import logging
 import os
 import shutil
 import tempfile
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 logger = logging.getLogger("vpinfe.common.info_restore")
@@ -84,8 +84,10 @@ def copy_aside(info_path, when=None):
     """
     path = backup_path(info_path, when)
     while os.path.exists(path):        # never overwrite a restore point
-        when = when or datetime.now(timezone.utc)
-        when = when.replace(second=(when.second + 1) % 60)
+        # A whole second, not the second field: replace(second=(s + 1) % 60) wraps 59 to
+        # 0, and the name that is supposed to be newer then sorts 59 seconds older. These
+        # names are the only ordering a restore has.
+        when = (when or datetime.now(timezone.utc)) + timedelta(seconds=1)
         path = backup_path(info_path, when)
     shutil.copy2(info_path, path)
     return path

--- a/tests/test_info_restore.py
+++ b/tests/test_info_restore.py
@@ -14,6 +14,7 @@ from tempfile import TemporaryDirectory
 from common.info_restore import (
     backup_names,
     backup_path,
+    copy_aside,
     converted_by_newer,
     restorable_backup,
     restore_library,
@@ -195,3 +196,36 @@ class NamingTests(RestoreTestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class CollisionOrderingTests(RestoreTestCase):
+    """Two backups in the same second still sort in the order they were made.
+
+    The names are the only ordering a restore has: it takes the newest readable one. A
+    bump that wrapped 59 to 0 made the newer file sort 59 seconds older, so a restore
+    could reach past a good backup to an older one.
+    """
+
+    def _two_at(self, when):
+        table_dir = self.root / "Dr. Dude"
+        table_dir.mkdir()
+        info = table_dir / "Dr. Dude.info"
+        info.write_text(json.dumps(OURS), encoding="utf-8")
+        first = copy_aside(str(info), when)
+        second = copy_aside(str(info), when)
+        return Path(first).name, Path(second).name
+
+    def test_a_collision_on_the_last_second_of_a_minute_still_sorts_forward(self):
+        from datetime import datetime, timezone
+
+        first, second = self._two_at(datetime(2026, 8, 1, 12, 30, 59, tzinfo=timezone.utc))
+
+        self.assertGreater(second, first)
+
+    def test_a_collision_at_midnight_rolls_the_date(self):
+        from datetime import datetime, timezone
+
+        first, second = self._two_at(datetime(2026, 8, 1, 23, 59, 59, tzinfo=timezone.utc))
+
+        self.assertGreater(second, first)
+        self.assertIn("20260802T000000Z", second)


### PR DESCRIPTION
`copy_aside` bumps the timestamp when two backups for one table land in the same second,
and it did that with `replace(second=(s + 1) % 60)`. On the last second of a minute that
wraps to 0, so the file meant to be newer gets a name that sorts 59 seconds *older* — and
those names are the only ordering a restore has.

In practice nobody backs up the same table twice inside a second, so this is really about
the collision path being correct where automated runs exercise it rather than a bug people
were hitting.

Adding a whole second instead of rewriting the second field rolls the minute, the hour and
the date. Two tests cover the minute and midnight boundaries; both fail without the change.
