### PR TITLE
Restore collections a newer VPinFE upgraded

### DIFF
--- a/clioptions.py
+++ b/clioptions.py
@@ -32,10 +32,12 @@ def buildMetaData(downloadMedia: bool = True, updateAll: bool = True, tableName:
 
 def restore_info_files(table_name: str = None, progress_cb=None, log_cb=None):
     from common.config_access import SettingsConfig
+    from common.paths import CONFIG_DIR
 
     return info_restore.restore_library(
         SettingsConfig.from_config(iniconfig).table_root_dir,
-        table_name=table_name, progress_cb=progress_cb, log_cb=log_cb)
+        table_name=table_name, config_dir=CONFIG_DIR,
+        progress_cb=progress_cb, log_cb=log_cb)
 
 
 def listMissingTables():
@@ -118,7 +120,7 @@ def parseArgs():
     parser.add_argument("--no-media", action="store_true", help="Do not download images when building meta.ini")
     parser.add_argument("--update-all", action="store_true", help="Reparse all tables when building meta.ini")
     parser.add_argument("--user-media", action="store_true", help="With --buildmeta: skip vpinmediadb downloads and claim existing local media as user-sourced")
-    parser.add_argument("--restore-info", action="store_true", help="Put back the .info files a newer VPinFE saved before converting them, for every table that has one. Your current .info is kept first")
+    parser.add_argument("--restore-info", action="store_true", help="Put back the table info and collections a newer VPinFE saved before upgrading them. Your current files are kept first")
     parser.add_argument("--table", help="Specify a single table folder name to process with --buildmeta, --claim-user-media or --restore-info")
 
     args, unknown = parser.parse_known_args()  # macOS-friendly parsing

--- a/common/info_restore.py
+++ b/common/info_restore.py
@@ -21,18 +21,24 @@ the user never chose which ones converted and cannot be asked to choose which co
 
 from __future__ import annotations
 
+import configparser
 import contextlib
+from datetime import datetime, timedelta, timezone
 import json
 import logging
 import os
+from pathlib import Path
 import shutil
 import tempfile
-from datetime import datetime, timedelta, timezone
-from pathlib import Path
 
 logger = logging.getLogger("vpinfe.common.info_restore")
 
 BACKUP_MARKER = ".vpinfe-"
+COLLECTIONS_NAME = "collections.ini"
+# Both files record the schema under a [vpinfe] / "vpinfe" section, so the rule for "can
+# this build read it" is the same in each: no schema key means it predates versioning.
+SCHEMA_SECTION = "vpinfe"
+SCHEMA_KEY = "schema"
 
 
 def converted_by_newer(meta):
@@ -60,13 +66,44 @@ def backup_names(names, info_name):
 
 
 def backup_schema(path):
-    """The schema a saved copy declares, or None when it predates versioning."""
+    """The schema a saved .info declares, or None when it predates versioning."""
     with open(path, encoding="utf-8") as handle:
         data = json.load(handle)
-    section = data.get("vpinfe") if isinstance(data, dict) else None
+    section = data.get(SCHEMA_SECTION) if isinstance(data, dict) else None
     if not isinstance(section, dict):
         return None
-    return int(section.get("schema") or 0) or None
+    return int(section.get(SCHEMA_KEY) or 0) or None
+
+
+def collections_schema(path):
+    """The schema a saved collections.ini declares, or None when it predates versioning."""
+    parser = configparser.ConfigParser()
+    parser.read(path, encoding="utf-8")
+    if SCHEMA_SECTION not in parser:
+        return None
+    return int(parser[SCHEMA_SECTION].get(SCHEMA_KEY, 0) or 0) or None
+
+
+def newest_readable_backup(directory, filename, schema_reader, names=None):
+    """The newest backup of `filename` this build can read, or None.
+
+    A copy written by a newer VPinFE is stepped over rather than ending the search - the
+    one behind it is usually what is wanted.
+    """
+    directory = Path(directory)
+    if names is None:
+        try:
+            names = os.listdir(directory)
+        except OSError:
+            return None
+    for name in backup_names(names, filename):
+        candidate = directory / name
+        try:
+            if schema_reader(candidate) is None:
+                return str(candidate)
+        except Exception:
+            logger.warning("Unreadable saved copy, skipping: %s", candidate)
+    return None
 
 
 def backup_path(info_path, when=None):
@@ -149,36 +186,26 @@ def table_dirs(table_root, table_name=None):
 
 
 def restorable_backup(table_dir, names=None):
-    """The saved copy this build would put back in this folder, or None.
-
-    Newest first, and the first one this build can actually read wins. A copy written by a
-    newer VPinFE is stepped over rather than treated as the end of the list - the one
-    behind it is usually exactly what is wanted.
-
-    Reads each candidate, so callers pass `names` when they have already listed the folder.
-    Only folders holding a saved copy pay for it, which for anyone who never ran a newer
-    VPinFE is none of them.
-    """
+    """The saved .info this build would put back in this folder, or None."""
     table_dir = Path(table_dir)
-    if names is None:
-        try:
-            names = os.listdir(table_dir)
-        except OSError:
-            return None
-    info_name = f"{table_dir.name}.info"
-    for name in backup_names(names, info_name):
-        candidate = table_dir / name
-        try:
-            schema = backup_schema(candidate)
-        except (OSError, ValueError):
-            logger.warning("Unreadable saved copy, skipping: %s", candidate)
-            continue
-        if schema is None:
-            return str(candidate)
-    return None
+    return newest_readable_backup(
+        table_dir, f"{table_dir.name}.info", backup_schema, names)
 
 
-def restore_library(table_root, table_name=None, progress_cb=None, log_cb=None):
+def restorable_collections_backup(config_dir):
+    """The saved collections.ini this build would put back, or None."""
+    return newest_readable_backup(config_dir, COLLECTIONS_NAME, collections_schema)
+
+
+def restore_file(path, backup):
+    """Put `backup` in place at `path`, keeping what is there now."""
+    if os.path.exists(path):
+        copy_aside(str(path))
+    replace_atomic(backup, path)
+
+
+def restore_library(table_root, table_name=None, config_dir=None,
+                    progress_cb=None, log_cb=None):
     """Put back the newest readable copy in every folder that has one.
 
     Never stops on one bad folder: an unreadable file is the state somebody is trying to
@@ -191,7 +218,8 @@ def restore_library(table_root, table_name=None, progress_cb=None, log_cb=None):
 
     folders = table_dirs(table_root, table_name)
     total = len(folders)
-    result = {"restored": 0, "nothing_to_restore": 0, "failed": 0, "failures": []}
+    result = {"restored": 0, "nothing_to_restore": 0, "failed": 0, "failures": [],
+              "collections_restored": False}
 
     log("Restoring table info from the copies saved before a newer VPinFE converted it. "
         "Your current info is kept first, so this can be undone too.")
@@ -208,9 +236,7 @@ def restore_library(table_root, table_name=None, progress_cb=None, log_cb=None):
             continue
         info_path = table_dir / f"{table_dir.name}.info"
         try:
-            if info_path.exists():
-                copy_aside(str(info_path))
-            replace_atomic(chosen, info_path)
+            restore_file(info_path, chosen)
         except OSError as exc:
             result["failed"] += 1
             result["failures"].append((table_dir.name, str(exc)))
@@ -218,6 +244,21 @@ def restore_library(table_root, table_name=None, progress_cb=None, log_cb=None):
             continue
         result["restored"] += 1
         log(f"Restored: {table_dir.name}")
+
+    # Collections live in the config directory, not a table folder, and a newer VPinFE
+    # rewrites their membership onto ids this build cannot resolve. Same rules: newest
+    # readable copy, keep what is there now, never delete.
+    if config_dir:
+        chosen = restorable_collections_backup(config_dir)
+        if chosen:
+            try:
+                restore_file(Path(config_dir) / COLLECTIONS_NAME, chosen)
+                result["collections_restored"] = True
+                log("Restored your collections.")
+            except OSError as exc:
+                result["failed"] += 1
+                result["failures"].append((COLLECTIONS_NAME, str(exc)))
+                log("Left as it is, could not be restored: your collections")
 
     log(_summary(result))
     return result
@@ -231,9 +272,11 @@ def _summary(result):
     if not result["restored"]:
         return "Nothing to restore - no table has info saved by a newer VPinFE."
     summary = (
-        f"Restored {_tables(result['restored'])}. Their ratings, favourites, tags and play "
+        f"Restored {_tables(result['restored'])}. Their ratings, favorites, tags and play "
         "counts are back as this version recorded them."
     )
+    if result["collections_restored"]:
+        summary += " Your collections are back too."
     if result["nothing_to_restore"]:
         summary += (
             f" {_tables(result['nothing_to_restore'])} were never converted, so there was "

--- a/managerui/pages/info_restore_dialog.py
+++ b/managerui/pages/info_restore_dialog.py
@@ -14,8 +14,8 @@ The list is there to answer "what will this touch", not to be picked from.
 from __future__ import annotations
 
 import asyncio
-import logging
 from datetime import datetime
+import logging
 from queue import Queue
 
 from nicegui import run, ui
@@ -31,12 +31,12 @@ _MUTED = ('color: var(--ink-muted) !important; background: var(--surface) !impor
           'border: 1px solid var(--line); border-radius: 18px; padding: 4px 10px;')
 
 INTRO = (
-    "Puts your ratings, favourites, tags and play counts back to how they were{when}. "
-    "Your current .info files are backed up first."
+    "Puts your ratings, favorites, tags, play counts and collections back to how they "
+    "were{when}. Your current files are backed up first."
 )
 
 DETAIL = (
-    "Tables a newer VPinFE never touched are left exactly as they are."
+    "Anything a newer VPinFE never touched is left exactly as it is."
 )
 
 
@@ -56,16 +56,16 @@ def _backup_date(stamp):
     return parsed.strftime("%d %B %Y").lstrip("0")
 
 
-def _strip(icon, colour, headline, detail, actions):
+def _strip(icon, color, headline, detail, actions):
     """One row: icon, text, actions.
 
     The text column needs `grow min-w-0` and the row `flex-nowrap`, or a long detail line
     grows past the available width and pushes the icon onto a line of its own.
     """
     with ui.card().classes('w-full mb-3').style(
-            f'background: var(--surface-soft); border: 1px solid {colour};'):
+            f'background: var(--surface-soft); border: 1px solid {color};'):
         with ui.row().classes('w-full items-center gap-4 px-4 py-3 flex-wrap md:flex-nowrap'):
-            ui.icon(icon, size='24px').classes('shrink-0').style(f'color: {colour};')
+            ui.icon(icon, size='24px').classes('shrink-0').style(f'color: {color};')
             with ui.column().classes('gap-1 grow min-w-0'):
                 ui.label(headline).classes('text-sm font-medium').style('color: var(--ink);')
                 ui.label(detail).classes('text-xs').style('color: var(--ink-muted);')
@@ -86,6 +86,23 @@ def _when():
     return f" on {date}" if date else " before the upgrade"
 
 
+def _collections_restorable():
+    try:
+        return table_service.collections_restorable()
+    except Exception:
+        logger.exception("Could not check for a saved collections file")
+        return False
+
+
+def _subject(count, collections):
+    """What a newer VPinFE upgraded, named as the user would name it."""
+    if count and collections:
+        return f"{_files(count)} and your collections"
+    if collections:
+        return "your collections"
+    return _files(count)
+
+
 def _restorable_names():
     try:
         return table_service.restorable_table_names()
@@ -96,7 +113,8 @@ def _restorable_names():
 
 def open_restore_dialog(on_done=None) -> None:
     names = _restorable_names()
-    if not names:
+    collections = _collections_restorable()
+    if not names and not collections:
         ui.notify("There are no backups to restore.", type='info')
         return
 
@@ -111,7 +129,8 @@ def open_restore_dialog(on_done=None) -> None:
         with intro_container:
             ui.label(INTRO.format(when=_when())).classes('text-sm').style('color: var(--ink);')
             ui.label(DETAIL).classes('text-xs').style('color: var(--ink-muted);')
-            with ui.expansion(f'Show the {len(names)} tables').classes('w-full'):
+            if names:
+              with ui.expansion(f'Show the {len(names)} tables').classes('w-full'):
                 with ui.column().classes('w-full p-2').style(
                         'max-height: 14rem; overflow: auto;'):
                     for name in names:
@@ -197,13 +216,14 @@ def render_restore_banner(on_done=None) -> None:
     """Say something only when a newer VPinFE has been here."""
     _render_unreadable_warning()
     names = _restorable_names()
-    if not names:
+    collections = _collections_restorable()
+    if not names and not collections:
         return
 
     _strip(
         'history', 'var(--neon-cyan)',
-        f'A newer VPinFE upgraded {_files(len(names))}.',
-        'Restore puts your ratings, favourites, tags and play counts back to how this '
+        f'A newer VPinFE upgraded {_subject(len(names), collections)}.',
+        'Restore puts your ratings, favorites, tags and play counts back to how this '
         'version recorded them, and backs up the current files first.',
         lambda: ui.button('Restore backups', icon='history',
                           on_click=lambda: open_restore_dialog(on_done)).style(_ACCENT),

--- a/managerui/services/table_service.py
+++ b/managerui/services/table_service.py
@@ -14,6 +14,7 @@ from common import metadata_service
 from common.vpxcollections import VPXCollections
 from common.vpxparser import VPXParser
 
+from common.paths import CONFIG_DIR
 from managerui.paths import COLLECTIONS_PATH, VPINFE_INI_PATH, get_tables_path
 from managerui.services import table_index_service
 
@@ -417,15 +418,21 @@ def newest_backup_stamp():
     return table_repository.newest_backup_stamp()
 
 
+def collections_restorable():
+    """Whether a newer VPinFE left a collections file this build can put back."""
+    return bool(info_restore.restorable_collections_backup(CONFIG_DIR))
+
+
 def restorable_table_names():
     """Folders with a .info saved by a newer VPinFE, for the banner and its dialog."""
     return table_repository.restorable_table_names()
 
 
 def restore_info(progress_cb=None, log_cb=None, **kwargs):
-    """Put back the .info files a newer VPinFE converted, library-wide."""
+    """Put back what a newer VPinFE upgraded: every table's .info, and the collections."""
     result = info_restore.restore_library(
-        get_tables_path(), progress_cb=progress_cb, log_cb=log_cb, **kwargs)
+        get_tables_path(), config_dir=CONFIG_DIR,
+        progress_cb=progress_cb, log_cb=log_cb, **kwargs)
     table_repository.refresh_tables()
     return result
 

--- a/tests/test_info_restore.py
+++ b/tests/test_info_restore.py
@@ -7,15 +7,15 @@ where the newer build left something this one has never seen.
 from __future__ import annotations
 
 import json
-import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
+import unittest
 
 from common.info_restore import (
     backup_names,
     backup_path,
-    copy_aside,
     converted_by_newer,
+    copy_aside,
     restorable_backup,
     restore_library,
     table_dirs,
@@ -229,3 +229,70 @@ class CollisionOrderingTests(RestoreTestCase):
 
         self.assertGreater(second, first)
         self.assertIn("20260802T000000Z", second)
+
+
+class CollectionsTests(RestoreTestCase):
+    """Collections are the other thing a newer VPinFE rewrites.
+
+    It moves membership onto ids this build cannot resolve, so every collection reads as
+    empty here. The file lives in the config directory rather than a table folder, which
+    is why it needs saying separately at all.
+    """
+
+    OURS_INI = "[Favorites]\nvpsids = vps-1,vps-2\n"
+    UPGRADED_INI = "[vpinfe]\nschema = 1\n\n[Favorites]\nvpsids = mJ8F4RqD8U,b9zqdR8qSh\n"
+
+    def _config_dir(self, live, saved=None):
+        config = self.root / "config"
+        config.mkdir()
+        (config / "collections.ini").write_text(live, encoding="utf-8")
+        if saved is not None:
+            (config / "collections.ini.vpinfe-20260729T143022Z").write_text(
+                saved, encoding="utf-8")
+        return config
+
+    def test_a_collections_file_a_newer_build_wrote_is_put_back(self):
+        config = self._config_dir(self.UPGRADED_INI, self.OURS_INI)
+
+        result = restore_library(self.root, config_dir=config)
+
+        self.assertTrue(result["collections_restored"])
+        self.assertEqual((config / "collections.ini").read_text(encoding="utf-8"),
+                         self.OURS_INI)
+
+    def test_the_upgraded_file_is_kept_so_the_restore_is_reversible(self):
+        config = self._config_dir(self.UPGRADED_INI, self.OURS_INI)
+
+        restore_library(self.root, config_dir=config)
+
+        kept = [p.read_text(encoding="utf-8") for p in config.iterdir()
+                if ".vpinfe-" in p.name]
+        self.assertIn(self.UPGRADED_INI, kept)
+
+    def test_a_saved_copy_this_build_cannot_read_is_refused(self):
+        """A copy carrying a schema was written by a newer VPinFE. Putting it back would
+        leave membership this build still cannot resolve."""
+        config = self._config_dir(self.UPGRADED_INI, self.UPGRADED_INI)
+
+        result = restore_library(self.root, config_dir=config)
+
+        self.assertFalse(result["collections_restored"])
+
+    def test_no_saved_copy_means_collections_are_left_alone(self):
+        config = self._config_dir(self.OURS_INI)
+
+        result = restore_library(self.root, config_dir=config)
+
+        self.assertFalse(result["collections_restored"])
+        self.assertEqual((config / "collections.ini").read_text(encoding="utf-8"),
+                         self.OURS_INI)
+
+    def test_collections_restore_without_any_table_backups(self):
+        """The two are independent: a library nobody upgraded can still have had its
+        collections rewritten."""
+        config = self._config_dir(self.UPGRADED_INI, self.OURS_INI)
+
+        result = restore_library(self.root, config_dir=config)
+
+        self.assertEqual(result["restored"], 0)
+        self.assertTrue(result["collections_restored"])


### PR DESCRIPTION
The restore added in #89 covers every table's `.info`. It does not cover `collections.ini`,
and a newer VPinFE rewrites that too — moving membership onto table ids this release can't
resolve, so every collection reads as empty. That file also had no backup at all and was
written in place.

It's part of the same walk now. Same rules as a `.info`: newest saved copy this build can
read, current file kept first, nothing deleted. The readability rule needed no invention —
both files record the schema under a `vpinfe` section, so "no schema key means it predates
versioning" reads the same in JSON and INI.

The two are independent: a library nobody upgraded can still have had its collections
rewritten, and the banner says whichever is true.

Restoring half of somebody's data automatically and leaving the rest to a manual file
rename is worse than doing both or neither.
