### PR TITLE
Keep the user's value when a config option changes section

### DIFF
--- a/common/iniconfig.py
+++ b/common/iniconfig.py
@@ -7,12 +7,35 @@ import string
 
 logger = logging.getLogger("vpinfe.common.iniconfig")
 
+# (from, to, key) for options that changed section. Applied on every read, so an ini
+# written by any earlier build lands in the right place.
+_MOVED_OPTIONS = (
+	('Settings', 'Displays', 'cabmode'),
+	('Settings', 'DOF', 'enabledof'),
+	('Displays', 'Settings', 'splashscreen'),
+)
+
 
 def _generate_machine_id(length: int = 64) -> str:
 	alphabet = string.ascii_letters + string.digits
 	return ''.join(secrets.choice(alphabet) for _ in range(length))
 
 class IniConfig:
+
+	def _move_option(self, old_section, new_section, key) -> bool:
+		"""Move one option to the section it lives in now, keeping the user's value.
+
+		The destination section may not exist yet: this runs before the defaults are
+		filled in, and filling them in is what creates sections.
+		"""
+		if not self.config.has_option(old_section, key):
+			return False
+		if not self.config.has_section(new_section):
+			self.config.add_section(new_section)
+		if not self.config.has_option(new_section, key):
+			self.config.set(new_section, key, self.config.get(old_section, key))
+		self.config.remove_option(old_section, key)
+		return True
 
 	def __init__(self, configfilepath):
 		
@@ -139,8 +162,16 @@ class IniConfig:
 				self.save()
 
 		self.config.read(configfilepath)
-		# Add any missing default options
 		changed = False
+
+		# Before the defaults, not after. Every key below has a default, so once one is
+		# written "copy only if absent" copies nothing and remove_option then drops what
+		# the user set. cabmode and enabledof both did that: a cabinet came back from an
+		# upgrade with cab mode and DOF off, and nothing said why.
+		for old_section, new_section, key in _MOVED_OPTIONS:
+			changed |= self._move_option(old_section, new_section, key)
+
+		# Add any missing default options
 		for section, defaults in self.defaults.items():
 			if not self.config.has_section(section):
 				self.config.add_section(section)
@@ -149,27 +180,6 @@ class IniConfig:
 				if not self.config.has_option(section, key):
 					self.config.set(section, key, value)
 					changed = True
-
-		# Migrate cabmode from [Settings] to [Displays] if present.
-		if self.config.has_option('Settings', 'cabmode'):
-			if not self.config.has_option('Displays', 'cabmode'):
-				self.config.set('Displays', 'cabmode', self.config.get('Settings', 'cabmode'))
-			self.config.remove_option('Settings', 'cabmode')
-			changed = True
-
-		# Migrate enabledof from [Settings] to [DOF] if present.
-		if self.config.has_option('Settings', 'enabledof'):
-			if not self.config.has_option('DOF', 'enabledof'):
-				self.config.set('DOF', 'enabledof', self.config.get('Settings', 'enabledof'))
-			self.config.remove_option('Settings', 'enabledof')
-			changed = True
-
-		# Migrate splashscreen from [Displays] to [Settings] if present.
-		if self.config.has_option('Displays', 'splashscreen'):
-			if not self.config.has_option('Settings', 'splashscreen'):
-				self.config.set('Settings', 'splashscreen', self.config.get('Displays', 'splashscreen'))
-			self.config.remove_option('Displays', 'splashscreen')
-			changed = True
 
 		# Remove legacy Logger.file option; logs always go to the standard config dir file.
 		if self.config.has_option('Logger', 'file'):

--- a/tests/test_iniconfig.py
+++ b/tests/test_iniconfig.py
@@ -128,5 +128,45 @@ class TestIniConfig(unittest.TestCase):
             self.assertEqual(config.config.get("Settings", "splashscreen"), "true")
 
 
+    def test_a_moved_option_keeps_the_users_value(self) -> None:
+        """The move has to happen before the defaults are written.
+
+        Every moved key has a default. Once one is in place, "copy only if absent"
+        copies nothing and remove_option drops the real value - so an upgrade turned
+        cab mode and DOF off and left nothing to explain why.
+        """
+        with TemporaryDirectory() as tmp:
+            ini_path = Path(tmp) / "vpinfe.ini"
+            ini_path.write_text(
+                "[Settings]\ncabmode = true\nenabledof = true\n"
+                "[Displays]\nsplashscreen = true\n",
+                encoding="utf-8",
+            )
+
+            config = IniConfig(str(ini_path))
+
+            self.assertEqual(config.config.get("Displays", "cabmode"), "true")
+            self.assertEqual(config.config.get("DOF", "enabledof"), "true")
+            self.assertEqual(config.config.get("Settings", "splashscreen"), "true")
+            # and the old spellings are gone, so the move is not repeated
+            self.assertFalse(config.config.has_option("Settings", "cabmode"))
+            self.assertFalse(config.config.has_option("Settings", "enabledof"))
+            self.assertFalse(config.config.has_option("Displays", "splashscreen"))
+
+    def test_a_moved_option_does_not_overwrite_a_value_already_there(self) -> None:
+        """If both spellings exist, the one in the current section wins."""
+        with TemporaryDirectory() as tmp:
+            ini_path = Path(tmp) / "vpinfe.ini"
+            ini_path.write_text(
+                "[Settings]\ncabmode = true\n[Displays]\ncabmode = false\n",
+                encoding="utf-8",
+            )
+
+            config = IniConfig(str(ini_path))
+
+            self.assertEqual(config.config.get("Displays", "cabmode"), "false")
+            self.assertFalse(config.config.has_option("Settings", "cabmode"))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Upgrading turns cab mode and DOF off. `cabmode`, `enabledof` and `splashscreen` each moved to a different section, and each migration copies the value across only when the new key is absent — but the defaults are filled in first, so the guard always finds one, copies nothing, and `remove_option` then deletes what the user had set. No backup, no log, nothing to explain it afterwards.

Repro with any ini carrying the old spellings:

    [Settings]
    cabmode = true
    enabledof = true

comes back as `[Displays] cabmode = false` and `[DOF] enabledof = false`.

The moves now run before the defaults. They needed a small helper on the way: filling in the defaults is what creates sections, so moving first meant the destination section might not exist yet.

All three keys are affected; cabmode and enabledof are the two a user notices.
